### PR TITLE
Disable Pdb2Pdb

### DIFF
--- a/src/cs/Directory.Build.props
+++ b/src/cs/Directory.Build.props
@@ -46,10 +46,6 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.DiaSymReader" Version="1.4.0">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/cs/Directory.Build.targets
+++ b/src/cs/Directory.Build.targets
@@ -12,8 +12,6 @@
 			<_SymPortablePath>$(_SymPortableDir)$(TargetName).pdb</_SymPortablePath>
 			<_SymWindowsDir>$(SymbolsOutputPath)windows/</_SymWindowsDir>
 			<_SymWindowsPath>$(_SymWindowsDir)$(TargetName).pdb</_SymWindowsPath>
-
-			<_Pdb2Pdb>$(PkgMicrosoft_DiaSymReader_Pdb2Pdb)\tools\Pdb2Pdb.exe</_Pdb2Pdb>
 		</PropertyGroup>
 
 		<MakeDir Directories="$(_SymPortableDir);$(_SymWindowsDir)" />
@@ -21,6 +19,5 @@
 		<Copy SourceFiles="$(TargetPath)" DestinationFiles="$(_SymAssemblyPath)" UseHardlinksIfPossible="true" />
 		<Copy SourceFiles="$(_TargetPdbPath)" DestinationFiles="$(_SymPortablePath)" UseHardlinksIfPossible="true" />
 
-		<Exec Command='"$(_Pdb2Pdb)" "$(TargetPath)" /out "$(_SymWindowsPath)"' IgnoreExitCode="false" />
 	</Target>
 </Project>


### PR DESCRIPTION
* Temporarily disable pdb2pdb to get single feed working. The tool is not available in the nuget feed. We can add a separate build step to do this at a later time. pdb2pdb is needed to convert the `portable` .pdbs to `full` .pdbs for older .NET versions. For .NET 6.0, the portable .pdbs should be sufficient.
* If this package is added back, it should be `"Microsoft.DiaSymReader.Pdb2Pdb"`, as this was previously changed in error.