### PR TITLE
Reset the TaskChain if one of them is cancelled.

### DIFF
--- a/src/cs/Ssh/TaskChain.cs
+++ b/src/cs/Ssh/TaskChain.cs
@@ -49,6 +49,16 @@ internal class TaskChain : IDisposable
 		try
 		{
 			await semaphore.WaitAsync(cancellation).ConfigureAwait(false);
+			
+			if (runInSequenceTask != null && 
+				(runInSequenceTask.IsCanceled || runInSequenceTask.Exception != null))
+			{
+				// If one task in the sequence is cancelled we have to reset runInSequenceTask 
+				// so that all subeequent queueing will succeed.
+				runInSequenceTask = null;
+			}
+
+			cancellation.ThrowIfCancellationRequested();
 			if (runInSequenceTask == null)
 			{
 				runInSequenceTask = Task.Run(


### PR DESCRIPTION
We saw an indication in telemetry that a task in TaskChain gets cancelled and making subsequent queueing of tasks fail.
This change will reset the TaskChain in any task fails or errors out.