### PR TITLE
Turn off fail-fast for PR builds

### DIFF
--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -8,6 +8,7 @@ on:
 jobs:
   builds:
     strategy:
+      fail-fast: false
       matrix:
         os: [macOS-latest, windows-latest]
 


### PR DESCRIPTION
When one of the build strategies (mac or windows) fails it cancels the other. Turning this setting off allows both to run to completion so we can rerun less when diagnosing issues.