### PR TITLE
Add can-change-port extension

### DIFF
--- a/ProtocolExtensions.md
+++ b/ProtocolExtensions.md
@@ -66,3 +66,8 @@ Round-trip connection latency between SSH client and server are measured as foll
  1. Include in each sent packet an extra 32-bit value that is the time delta (_`Td`_) since the last-recorded receive time (_`Tr`_). This follows the 64-bit last-received packet sequence number appended for reconnection support.
  1. After receiving each packet, find the message in the reconnect cache that matches the last-received sequence number, and get its send time (_`Ts`_). Also read the remote delta (_`Td`_) time from the end of the packet.
  1. Then the round-trip latency can be computed as _`(Tr - Ts - Td)`_. In other words, it measures the time between sending one packet and receiving the next, not including the time between receiving and sending on the remote side (and avoiding overlaps).
+
+## Extension: Forward non-requested port
+Extension ID: `can-change-port`
+
+The SSH protocol specifies that the port forwarded in response to a port forwarding request must match the requested port. This extension indicates that the SSH session supports forwarding a port that differs from the requested port. When the requested port is not available, this allows the recipient of the request to select an appropriate port and send a single response, instead of informing the sender that it needs to request a different port.

--- a/src/cs/Ssh.Tcp/Services/LocalPortForwarder.cs
+++ b/src/cs/Ssh.Tcp/Services/LocalPortForwarder.cs
@@ -75,10 +75,10 @@ public class LocalPortForwarder : SshService
 		var listenAddress = LocalIPAddress;
 		try
 		{
-			// When the requested port number is not 0 (random) then changing the port number
-			// is not compliant with the SSH protocol. Only allow it if the remote side is
-			// this library, which is known to support it.
+			// Older versions of this library don't support the can-change-port extension,
+			// so the version string is checked instead.
 			bool canChangePort = LocalPort == 0 ||
+				this.Session.ProtocolExtensions.ContainsKey(SshProtocolExtensionNames.CanChangePort) ||
 				this.pfs.Session.RemoteVersion?.IsVsSsh == true;
 			var trace = this.pfs.Session.Trace;
 			this.listener = await this.pfs.TcpListenerFactory.CreateTcpListenerAsync(

--- a/src/cs/Ssh.Tcp/Services/LocalPortForwarder.cs
+++ b/src/cs/Ssh.Tcp/Services/LocalPortForwarder.cs
@@ -78,7 +78,7 @@ public class LocalPortForwarder : SshService
 			// Older versions of this library don't support the can-change-port extension,
 			// so the version string is checked instead.
 			bool canChangePort = LocalPort == 0 ||
-				this.Session.ProtocolExtensions.ContainsKey(SshProtocolExtensionNames.CanChangePort) ||
+				this.Session.ProtocolExtensions?.ContainsKey(SshProtocolExtensionNames.CanChangePort) == true ||
 				this.pfs.Session.RemoteVersion?.IsVsSsh == true;
 			var trace = this.pfs.Session.Trace;
 			this.listener = await this.pfs.TcpListenerFactory.CreateTcpListenerAsync(

--- a/src/cs/Ssh/MultiChannelStream.cs
+++ b/src/cs/Ssh/MultiChannelStream.cs
@@ -58,7 +58,6 @@ public class MultiChannelStream : IDisposable
 		this.session.ChannelOpening += OnChannelOpening;
 	}
 
-
 	/// <summary>
 	/// Gets a value indicating whether the session is closed.
 	/// </summary>

--- a/src/cs/Ssh/Services/KeyExchangeService.cs
+++ b/src/cs/Ssh/Services/KeyExchangeService.cs
@@ -293,22 +293,6 @@ internal class KeyExchangeService : SshService
 						SshTraceEventIds.AlgorithmNegotiation,
 						$"Client's {nameof(ExchangeContext.KeyExchange)} guess was {guessResult}.");
 					this.exchangeContext.DiscardGuessedInit = !negotiatedKexAlgorthmIsPreferred;
-					{
-						// VS-SSH v2 had a bug in the logic for determining whether the guess was correct.
-						// Use that alternate logic here to preserve compatibility.
-						bool clientAndServerHaveSamePreference =
-							message.KeyExchangeAlgorithms?.FirstOrDefault() ==
-							Session.Config.KeyExchangeAlgorithms.FirstOrDefault(
-								(a) => a?.IsAvailable == true)?.Name;
-						if (!clientAndServerHaveSamePreference)
-						{
-							Session.Trace.TraceEvent(
-								TraceEventType.Verbose,
-								SshTraceEventIds.AlgorithmNegotiation,
-								$"Ignoring correct guess for compatibility with older client.");
-							this.exchangeContext.DiscardGuessedInit = true;
-						}
-					}
 				}
 
 				this.exchangeContext.ClientKexInitPayload = message.ToBuffer().ToArray();

--- a/src/cs/Ssh/Services/KeyExchangeService.cs
+++ b/src/cs/Ssh/Services/KeyExchangeService.cs
@@ -293,9 +293,6 @@ internal class KeyExchangeService : SshService
 						SshTraceEventIds.AlgorithmNegotiation,
 						$"Client's {nameof(ExchangeContext.KeyExchange)} guess was {guessResult}.");
 					this.exchangeContext.DiscardGuessedInit = !negotiatedKexAlgorthmIsPreferred;
-
-					if (negotiatedKexAlgorthmIsPreferred &&
-						Session.RemoteVersion!.IsVsSsh && Session.RemoteVersion!.Version?.Major < 3)
 					{
 						// VS-SSH v2 had a bug in the logic for determining whether the guess was correct.
 						// Use that alternate logic here to preserve compatibility.
@@ -578,14 +575,6 @@ internal class KeyExchangeService : SshService
 		var negotiationDetail = $"{label} negotiation: " +
 			$"Server ({string.Join(", ", serverAlgorithms)}) " +
 			$"Client ({string.Join(", ", clientAlgorithms)})";
-
-		if (Session.RemoteVersion!.IsVsSsh && Session.RemoteVersion.Version?.Major < 3)
-		{
-			// Older versions of ths library got this backward. Swap for back-compatibility.
-			var temp = serverAlgorithms;
-			serverAlgorithms = clientAlgorithms;
-			clientAlgorithms = temp;
-		}
 
 		foreach (var client in clientAlgorithms)
 		{

--- a/src/cs/Ssh/SshProtocolExtensionNames.cs
+++ b/src/cs/Ssh/SshProtocolExtensionNames.cs
@@ -38,4 +38,14 @@ public static class SshProtocolExtensionNames
 	/// it leverages some of the session history info for reconnect to compute latency.
 	/// </remarks>
 	public const string SessionLatency = "session-latency@microsoft.com";
+
+	/// <summary>
+	/// Enables forwarding of ports other that the requested port.
+	/// </summary>
+	/// <remarks>
+	/// When the requested port number is not 0 (random) then changing the port number
+	/// is not compliant with the SSH protocol. Only allow it if the remote side is
+	/// this library, which is known to support it.
+	/// </remarks>
+	public const string CanChangePort = "can-change-port@microsoft.com";
 }

--- a/src/cs/Ssh/SshSessionConfiguration.cs
+++ b/src/cs/Ssh/SshSessionConfiguration.cs
@@ -42,6 +42,7 @@ public class SshSessionConfiguration
 		ProtocolExtensions = new SortedSet<string>();
 		ProtocolExtensions.Add(SshProtocolExtensionNames.ServerSignatureAlgorithms);
 		ProtocolExtensions.Add(SshProtocolExtensionNames.OpenChannelRequest);
+		ProtocolExtensions.Add(SshProtocolExtensionNames.CanChangePort);
 
 		if (enableReconnect)
 		{

--- a/src/ts/ssh/services/keyExchangeService.ts
+++ b/src/ts/ssh/services/keyExchangeService.ts
@@ -286,25 +286,6 @@ export class KeyExchangeService extends SshService {
 					`Client's KeyExchange guess was ${guessResult}.`,
 				);
 				this.exchangeContext.discardGuessedInit = !negotiatedKexAlgorthmIsPreferred;
-
-				if (
-					negotiatedKexAlgorthmIsPreferred &&
-					this.session.remoteVersion!.isVsSsh &&
-					this.session.remoteVersion!.version?.startsWith('2.')
-				) {
-					// VS-SSH v2 had a bug in the logic for determining whether the guess was correct.
-					// Use that alternate logic here to preserve compatibility.
-					const clientAndServerHaveSamePreference =
-						message.keyExchangeAlgorithms?.[0] === config.keyExchangeAlgorithms[0]?.name;
-					if (!clientAndServerHaveSamePreference) {
-						this.trace(
-							TraceLevel.Verbose,
-							SshTraceEventIds.algorithmNegotiation,
-							'Ignoring correct guess for compatibility with older client.',
-						);
-						this.exchangeContext.discardGuessedInit = true;
-					}
-				}
 			}
 
 			this.exchangeContext.clientKexInitPayload = message.toBuffer();
@@ -653,16 +634,6 @@ export class KeyExchangeService extends SshService {
 			`${label} negotiation: ` +
 			`Server (${serverAlgorithms.join(', ')}) ` +
 			`Client (${clientAlgorithms.join(', ')})`;
-
-		if (
-			this.session.remoteVersion!.isVsSsh &&
-			this.session.remoteVersion!.version?.startsWith('2.')
-		) {
-			// Older versions of ths library got this backward. Swap for back-compatibility.
-			const temp = serverAlgorithms;
-			serverAlgorithms = clientAlgorithms;
-			clientAlgorithms = temp;
-		}
 
 		for (let client of clientAlgorithms) {
 			for (let server of serverAlgorithms) {

--- a/src/ts/ssh/sshSessionConfiguration.ts
+++ b/src/ts/ssh/sshSessionConfiguration.ts
@@ -44,6 +44,15 @@ export enum SshProtocolExtensionNames {
 	 * it leverages some of the session history info for reconnect to compute latency.
 	 */
 	sessionLatency = 'session-latency@microsoft.com',
+
+	/**
+	 * Enables forwarding of ports other that the requested port.
+	 *
+	 * When the requested port number is not 0 (random) then changing the port number
+	 * is not compliant with the SSH protocol. Only allow it if the remote side is
+	 * this library, which is known to support it.
+	 */
+	canChangePort = 'can-change-port@microsoft.com',
 }
 
 /**
@@ -56,6 +65,7 @@ export class SshSessionConfiguration {
 	public constructor(useSecurity: boolean = true) {
 		this.protocolExtensions.push(SshProtocolExtensionNames.serverSignatureAlgorithms);
 		this.protocolExtensions.push(SshProtocolExtensionNames.openChannelRequest);
+		this.protocolExtensions.push(SshProtocolExtensionNames.canChangePort);
 
 		this.services.set(KeyExchangeService, null);
 		this.services.set(ConnectionService, null);

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-	"version": "3.9",
+	"version": "3.10",
 	"publicReleaseRefSpec": [
 		"^refs/heads/main$",
 		"^refs/heads/releases/.+$"


### PR DESCRIPTION
This is a followup to the ssh version check change that was done when open sourcing the library. This allows us to not rely on the version name for the port switching behavior.
* Add a new `can-change-port` extension to indicate whether the ssh implementation supports changing ports.
* The `isVsSsh` check (which does this same thing) should be retained for older versions of the library which don't support the extension.
* Removes the `isVsSsh` check where it is no longer needed (for versions `2.x`).
* Bump the minor version.