### PR TITLE
Send kex-init message even with no encryption

### DIFF
--- a/src/cs/Ssh/IO/SshDataWriter.cs
+++ b/src/cs/Ssh/IO/SshDataWriter.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 
 using System;
-using System.Linq;
-using System.Security.Cryptography;
 using System.Text;
 
 namespace Microsoft.DevTunnels.Ssh.IO;

--- a/src/cs/Ssh/Messages/SshMessage.cs
+++ b/src/cs/Ssh/Messages/SshMessage.cs
@@ -27,7 +27,7 @@ public abstract class SshMessage
 
 	public abstract byte MessageType { get; }
 
-	protected Buffer RawBytes { get; private set; }
+	protected Buffer RawBytes { get; set; }
 
 	public void Read(ref SshDataReader reader)
 	{

--- a/src/cs/Ssh/Messages/Transport/DisconnectMessage.cs
+++ b/src/cs/Ssh/Messages/Transport/DisconnectMessage.cs
@@ -54,4 +54,9 @@ public class DisconnectMessage : SshMessage
 			writer.Write(Language, Encoding.ASCII);
 		}
 	}
+
+	public override string ToString()
+	{
+		return $"{base.ToString()}(Reason: {ReasonCode}, Description: {Description})";
+	}
 }

--- a/src/ts/ssh/messages/transportMessages.ts
+++ b/src/ts/ssh/messages/transportMessages.ts
@@ -53,6 +53,12 @@ export class DisconnectMessage extends SshMessage {
 			writer.writeString(this.language, 'ascii');
 		}
 	}
+
+	public toString() {
+		return `${super.toString()} (${SshDisconnectReason[this.reasonCode || 0]}: ${
+			this.description
+		})`;
+	}
 }
 
 export class IgnoreMessage extends SshMessage {


### PR DESCRIPTION
This makes `MultiChannelStream` (a simplified SSH session with no encryption) more conformant with the standard SSH protocol, by always sending a `SSH_MSG_KEXINIT` message with `none` for all algorithms immediately after the version handshake.

The change is backward-compatible because the previous code would already accept such a message and validate that it allowed `none` for all the algorithms. That validation is also simplified and optimized in this change.

The performance impact of the additional message should be negligible because neither side is waiting for the message or a response to it, so it does cause any additional delay.