### PR TITLE
SecureStream class

### DIFF
--- a/src/cs/Ssh.Tcp/Services/LocalPortForwarder.cs
+++ b/src/cs/Ssh.Tcp/Services/LocalPortForwarder.cs
@@ -192,6 +192,12 @@ public class LocalPortForwarder : SshService
 					tcpClient.Client.Abort();
 					continue;
 				}
+				catch (SshConnectionException)
+				{
+					// The session was disconnected.
+					tcpClient.Client.Abort();
+					break;
+				}
 				catch (ObjectDisposedException)
 				{
 					// The session was disposed.

--- a/src/cs/Ssh/MultiChannelStream.cs
+++ b/src/cs/Ssh/MultiChannelStream.cs
@@ -12,10 +12,12 @@ using Microsoft.DevTunnels.Ssh.Services;
 namespace Microsoft.DevTunnels.Ssh;
 
 /// <summary>
-/// Multiplexes multiple virtual streams (channels) over a single transport stream.
+/// Multiplexes multiple virtual streams (channels) over a single transport stream, using the
+/// SSH protocol while providing a simplified interface without any encryption or authentication.
 /// </summary>
 /// <remarks>
-/// Uses the channel-multiplexing capabilities of the SSH protocol (without any security).
+/// This class is a complement to <see cref="SecureStream"/>, which provides only the
+/// encryption and authentication functions of SSH.
 ///
 /// To communicate over multiple channels, two sides first establish a transport stream
 /// over a pipe, socket, or anything else. Then one side accepts a channel while the
@@ -119,14 +121,14 @@ public class MultiChannelStream : IDisposable
 	}
 
 	/// <summary>
-	/// Call to bind the transport stream to ssh session and exchange
-	/// initial messages with the remote peer. Waits for the protocol version exchange and
-	/// key exchange; additional message processing is kicked off as a background task chain.
+	/// Initiates the SSH session over the transport stream by exchanging initial messages with the
+	/// remote peer. Waits for the protocol version exchange and key exchange. Additional message
+	/// processing is kicked off as a background task chain.
 	/// </summary>
-	/// <throws>SshConnectionException if the connection failed due to a protocol
-	/// error.</throws>
-	/// <throws>TimeoutException if the ConnectTimeout property is set and the initial
-	/// version exchange could not be completed within the timeout.</throws>
+	/// <exception cref="SshConnectionException">The connection failed due to a protocol
+	/// error.</exception>
+	/// <exception cref="TimeoutException">The ConnectTimeout property is set and the initial
+	/// version exchange could not be completed within the timeout.</exception>
 	public Task ConnectAsync(CancellationToken cancellation = default) =>
 		this.session.ConnectAsync(this.transportStream, cancellation);
 

--- a/src/cs/Ssh/SecureStream.cs
+++ b/src/cs/Ssh/SecureStream.cs
@@ -1,0 +1,291 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.DevTunnels.Ssh.Events;
+
+namespace Microsoft.DevTunnels.Ssh;
+
+/// <summary>
+/// Establishes an end-to-end encrypted two-way authenticated data stream over an underlying
+/// transport stream, using the SSH protocol but providing simplified interface that is limited to
+/// a single duplex stream (channel).
+/// </summary>
+/// <remarks>
+/// This class is a complement to <see cref="MultiChannelStream"/>, which provides only the
+/// channel-multiplexing functions of SSH.
+/// 
+/// To establish a secure connection, the two sides first establish an insecure transport stream
+/// over a pipe, socket, or anything else. Then they encrypt and authenticate the connection
+/// before beginning to send and receive data.
+/// </remarks>
+public class SecureStream : Stream
+{
+	private readonly Stream transportStream;
+	private readonly SshSession session;
+	private readonly SshClientCredentials? clientCredentials;
+	private readonly SshServerCredentials? serverCredentials;
+	private SshStream? stream;
+
+	/// <summary>
+	/// Creates a secure stream over an underlying transport stream, using client credentials
+	/// to authenticate.
+	/// </summary>
+	/// <param name="transportStream">Underlying (insecure) transport stream.</param>
+	/// <param name="clientCredentials">Client authentication credentials.</param>
+	/// <param name="trace">Optional trace source for SSH protocol tracing.</param>
+	public SecureStream(
+		Stream transportStream,
+		SshClientCredentials clientCredentials,
+		TraceSource? trace = null)
+	{
+		this.transportStream = transportStream ??
+			throw new ArgumentNullException(nameof(transportStream));
+		this.session = new SshClientSession(
+			SshSessionConfiguration.Default,
+			trace ?? new TraceSource(nameof(MultiChannelStream)));
+
+		this.session.Authenticating += OnSessionAuthenticating;
+		this.session.Closed += OnSessionClosed;
+
+		this.clientCredentials = clientCredentials ??
+			throw new ArgumentNullException(nameof(clientCredentials));
+	}
+
+	/// <summary>
+	/// Creates a secure stream over an underlying transport stream, using server credentials
+	/// to authenticate.
+	/// </summary>
+	/// <param name="transportStream">Underlying (insecure) transport stream.</param>
+	/// <param name="serverCredentials">Server authentication credentials.</param>
+	/// <param name="trace">Optional trace source for SSH protocol tracing.</param>
+	public SecureStream(
+		Stream transportStream,
+		SshServerCredentials serverCredentials,
+		TraceSource? trace = null)
+	{
+		this.transportStream = transportStream ??
+			throw new ArgumentNullException(nameof(transportStream));
+		this.session = new SshServerSession(
+			SshSessionConfiguration.Default,
+			trace ?? new TraceSource(nameof(MultiChannelStream)));
+
+		this.session.Authenticating += OnSessionAuthenticating;
+		this.session.Closed += OnSessionClosed;
+
+		this.serverCredentials = serverCredentials ??
+			throw new ArgumentNullException(nameof(serverCredentials));
+	}
+
+	public event EventHandler<SshAuthenticatingEventArgs>? Authenticating;
+
+	/// <summary>
+	/// Gets a value indicating whether the session is closed.
+	/// </summary>
+	public bool IsClosed =>
+		this.session.IsClosed;
+
+	/// <summary>
+	/// Event that is rised when underlying ssh session is closed.
+	/// </summary>
+	/// <remarks>
+	/// The event is rised before the session stream is closed.
+	/// The stream will be closed after the event handler.
+	/// </remarks>
+	public EventHandler<SshSessionClosedEventArgs>? Closed
+	{
+		get;
+		set;
+	}
+
+	/// <summary>
+	/// Limits the amount of time that ConnectAsync() may wait for the initial
+	/// session handshake (version exchange).
+	/// </summary>
+	public TimeSpan? ConnectTimeout
+	{
+		get => this.session.ConnectTimeout;
+		set => this.session.ConnectTimeout = value;
+	}
+
+	/// <summary>
+	/// Initiates the SSH session over the transport stream by exchanging initial messages with the
+	/// remote peer. Waits for the protocol version exchange, key exchange, authentication, and
+	/// opened channel. Additional message processing is kicked off as a background task chain.
+	/// </summary>
+	/// <exception cref="SshConnectionException">The connection failed due to a protocol
+	/// error.</exception>
+	/// <exception cref="TimeoutException">The ConnectTimeout property is set and the initial
+	/// version exchange could not be completed within the timeout.</exception>
+	public async Task ConnectAsync(CancellationToken cancellation = default)
+	{
+		if (Authenticating == null)
+		{
+			throw new InvalidOperationException(
+				"An Authenticating event handler must be registered before connecting.");
+		}
+
+		if (this.serverCredentials != null)
+		{
+			var serverSession = (SshServerSession)this.session;
+			serverSession.Credentials = this.serverCredentials;
+		}
+
+		await this.session.ConnectAsync(this.transportStream, cancellation).ConfigureAwait(false);
+
+		SshChannel? channel = null;
+		if (this.clientCredentials != null)
+		{
+			SshConnectionException? ex = null;
+			var clientSession = (SshClientSession)this.session;
+			if (!(await clientSession.AuthenticateServerAsync(cancellation).ConfigureAwait(false)))
+			{
+				ex = new SshConnectionException(
+					"Server authentication failed.", SshDisconnectReason.HostKeyNotVerifiable);
+			}
+
+			if (ex == null && !(await clientSession.AuthenticateClientAsync(
+				this.clientCredentials, cancellation).ConfigureAwait(false)))
+			{
+				ex = new SshConnectionException(
+					"Client authentication failed.", SshDisconnectReason.NoMoreAuthMethodsAvailable);
+			}
+
+			if (ex != null)
+			{
+				await this.session.CloseAsync(ex.DisconnectReason, ex).ConfigureAwait(false);
+				throw ex;
+			}
+
+			channel = await this.session.OpenChannelAsync(cancellation).ConfigureAwait(false);
+		}
+		else
+		{
+			channel = await this.session.AcceptChannelAsync(cancellation).ConfigureAwait(false);
+		}
+
+		this.stream = CreateStream(channel);
+		channel.Closed += (_, _) =>
+		{
+			this.Dispose();
+		};
+	}
+
+	/// <summary>
+	/// Creates a stream instance for a channel. May be overridden to create a
+	/// <see cref="SshStream" /> subclass.
+	/// </summary>
+	protected virtual SshStream CreateStream(SshChannel channel)
+	{
+		return new SshStream(channel);
+	}
+
+	protected override void Dispose(bool disposing)
+	{
+		if (disposing)
+		{
+			this.stream?.Dispose();
+			this.session.Dispose();
+
+			// If the session has not connected yet, it doesn't know about the stream and won't dispose it.
+			// So we dispose it explicitly here.
+			this.transportStream.Dispose();
+		}
+
+		base.Dispose(disposing);
+	}
+
+	/// <summary>
+	/// Close the SSH session with <see cref="SshDisconnectReason.None"/> reason and dispose the underlying transport stream.
+	/// </summary>
+	public async Task CloseAsync()
+	{
+		await this.session.CloseAsync(SshDisconnectReason.None, this.session.GetType().Name + " disposed").ConfigureAwait(false);
+		this.session.Dispose();
+
+#if !NETSTANDARD2_0
+		await this.transportStream.DisposeAsync().ConfigureAwait(false);
+#else
+		this.transportStream.Dispose();
+#endif
+	}
+
+	/// <summary>
+	/// The SSH software name and version of the remote client,
+	/// parsed when a connection is made to the server
+	/// </summary>
+	public SshVersionInfo? RemoteVersion => this.session.RemoteVersion;
+
+	private void OnSessionAuthenticating(object? sender, SshAuthenticatingEventArgs e)
+	{
+		Authenticating?.Invoke(this, e);
+	}
+
+	private void OnSessionClosed(object? sender, SshSessionClosedEventArgs e)
+	{
+		this.session.Closed -= OnSessionClosed;
+		Closed?.Invoke(this, e);
+	}
+
+	public override bool CanRead => true;
+
+	public override bool CanWrite => true;
+
+	public override void Flush()
+	{
+		this.stream?.Flush();
+	}
+
+	public override int Read(byte[] buffer, int offset, int count)
+	{
+		var stream = this.stream ?? throw new InvalidOperationException("Stream is not connected.");
+		return stream.Read(buffer, offset, count);
+	}
+
+	public override void Write(byte[] buffer, int offset, int count)
+	{
+		var stream = this.stream ?? throw new InvalidOperationException("Stream is not connected.");
+		stream.Write(buffer, offset, count);
+	}
+
+	public override Task<int> ReadAsync(
+		byte[] buffer, int offset, int count, CancellationToken cancellation)
+	{
+		var stream = this.stream ?? throw new InvalidOperationException("Stream is not connected.");
+		return stream.ReadAsync(buffer, offset, count, cancellation);
+	}
+
+	public override Task WriteAsync(
+		byte[] buffer, int offset, int count, CancellationToken cancellation)
+	{
+		var stream = this.stream ?? throw new InvalidOperationException("Stream is not connected.");
+		return stream.WriteAsync(buffer, offset, count, cancellation);
+	}
+
+	#region Seek / position / length are not supported
+
+	public override bool CanSeek => false;
+
+	public override long Length => throw new NotSupportedException();
+
+	public override long Position
+	{
+		get => throw new NotSupportedException();
+		set => throw new NotSupportedException();
+	}
+
+	public override long Seek(long offset, SeekOrigin origin)
+	{
+		throw new NotSupportedException();
+	}
+
+	public override void SetLength(long value)
+	{
+		throw new NotSupportedException();
+	}
+
+	#endregion
+}

--- a/src/cs/Ssh/Services/AuthenticationService.cs
+++ b/src/cs/Ssh/Services/AuthenticationService.cs
@@ -475,8 +475,14 @@ internal class AuthenticationService : SshService
 	{
 		if (disposing)
 		{
-			disposeCancellationSource.Cancel();
-			disposeCancellationSource.Dispose();
+			try
+			{
+				disposeCancellationSource.Cancel();
+				disposeCancellationSource.Dispose();
+			}
+			catch (ObjectDisposedException)
+			{
+			}
 		}
 
 		base.Dispose(disposing);

--- a/src/cs/Ssh/SshSession.cs
+++ b/src/cs/Ssh/SshSession.cs
@@ -23,7 +23,9 @@ namespace Microsoft.DevTunnels.Ssh;
 /// Enables opening and accepting `SshChannel` instances.
 /// </summary>
 [DebuggerDisplay("{ToString(),nq}")]
+#pragma warning disable CA1506 // 'SshSession' is coupled with too many types.
 public class SshSession : IDisposable
+#pragma warning restore CA1506
 {
 	private readonly ConcurrentQueue<SshMessage> blockedMessages =
 		new ConcurrentQueue<SshMessage>();
@@ -633,10 +635,8 @@ public class SshSession : IDisposable
 		{
 			this.disposeCancellationSource.Cancel();
 
-			if (ex != null)
-			{
-				this.GetService<ConnectionService>()?.Close(ex);
-			}
+			ex ??= new SshConnectionException(message, reason);
+			this.GetService<ConnectionService>()?.Close(ex);
 
 			Closed?.Invoke(this, new SshSessionClosedEventArgs(reason, message, ex));
 		}
@@ -680,6 +680,9 @@ public class SshSession : IDisposable
 
 	protected virtual void Dispose(bool disposing)
 	{
+		var closedEx = this.closedException as SshConnectionException ??
+			new SshConnectionException("Session disposed.", this.closedException);
+
 		if (disposing)
 		{
 			if (!IsClosed)
@@ -701,11 +704,10 @@ public class SshSession : IDisposable
 						SshTraceEventIds.SessionClosing,
 						$"{this} Close()");
 					Closed?.Invoke(this, new SshSessionClosedEventArgs(
-						SshDisconnectReason.None, GetType().Name + " disposed", null));
+						closedEx.DisconnectReason, GetType().Name + " disposed", closedEx));
 				}
 			}
 
-			var closedEx = new SshConnectionException("Connection closed.", this.closedException);
 			InvokeRequestHandler(null, null, closedEx);
 			this.connectCompletionSource?.TrySetException(closedEx);
 
@@ -891,9 +893,10 @@ public class SshSession : IDisposable
 		DisconnectMessage message, CancellationToken cancellation)
 	{
 		cancellation.ThrowIfCancellationRequested();
-		await CloseAsync(
-			message.ReasonCode,
-			message.Description ?? "Received disconnect message.").ConfigureAwait(false);
+
+		var description = !string.IsNullOrEmpty(message.Description) ? message.Description :
+			"Received disconnect message.";
+		await CloseAsync(message.ReasonCode, description).ConfigureAwait(false);
 	}
 
 	private async Task HandleMessageAsync(

--- a/src/ts/ssh/index.ts
+++ b/src/ts/ssh/index.ts
@@ -86,5 +86,6 @@ export { SessionMetrics } from './metrics/sessionMetrics';
 export { ChannelMetrics } from './metrics/channelMetrics';
 export { SessionContour } from './metrics/sessionContour';
 export { MultiChannelStream } from './multiChannelStream';
+export { SecureStream } from './secureStream';
 
 export { Trace, TraceLevel, SshTraceEventIds } from './trace';

--- a/src/ts/ssh/multiChannelStream.ts
+++ b/src/ts/ssh/multiChannelStream.ts
@@ -17,8 +17,16 @@ import { Trace, TraceLevel, SshTraceEventIds } from './trace';
 import { ChannelOpenMessage } from './messages/connectionMessages';
 
 /**
- * This class allows to establish an ssh session with no security beign defined.
- * Both side could open multiple channel to send/receive data.
+ * Multiplexes multiple virtual streams (channels) over a single transport stream, using the
+ * SSH protocol while providing a simplified interface without any encryption or authentication.
+ *
+ * This class is a complement to `SecureStream`, which provides only the encryption and
+ * authentication functions of SSH.
+ *
+ * To communicate over multiple channels, two sides first establish a transport stream
+ * over a pipe, socket, or anything else. Then one side accepts a channel while the
+ * other side opens a channel. Either side can both open and accept channels over the
+ * same transport stream, as long as the other side does the complementary action.
  */
 export class MultiChannelStream implements Disposable {
 	private readonly session: SshSession;
@@ -69,7 +77,9 @@ export class MultiChannelStream implements Disposable {
 	}
 
 	/**
-	 * Connects ssh session.
+	 * Initiates the SSH session over the transport stream by exchanging initial messages with the
+	 * remote peer. Waits for the protocol version exchange and key exchange. Additional message
+	 * processing is kicked off as a background promise chain.
 	 * @param cancellation optional cancellation token.
 	 */
 	public async connect(cancellation?: CancellationToken) {
@@ -77,7 +87,7 @@ export class MultiChannelStream implements Disposable {
 	}
 
 	/**
-	 * Accept a new channel on the ssh session.
+	 * Asynchronously waits for the other side to open a channel.
 	 * @param channelType optional channel type
 	 * @param cancellation optional cancellation token.
 	 */
@@ -91,7 +101,7 @@ export class MultiChannelStream implements Disposable {
 	}
 
 	/**
-	 * Accept a remote ssh stream.
+	 * Asynchronously waits for the other side to open a channel.
 	 * @param channelType optional channel type
 	 * @param cancellation optional cancellation token.
 	 */
@@ -103,7 +113,7 @@ export class MultiChannelStream implements Disposable {
 	}
 
 	/**
-	 * Open a channel to a remote ssh session
+	 * Opens a channel and asynchronously waits for the other side to accept it.
 	 * @param channelType optional channel type
 	 * @param cancellation optional cancellation token.
 	 */
@@ -121,7 +131,7 @@ export class MultiChannelStream implements Disposable {
 	}
 
 	/**
-	 * open a stream to a remote ssh session
+	 * Opens a channel and asynchronously waits for the other side to accept it.
 	 * @param channelType optional channel type
 	 * @param cancellation optional cancellation token.
 	 */
@@ -140,7 +150,8 @@ export class MultiChannelStream implements Disposable {
 	}
 
 	/**
-	 * Connect ssh session and run it until closed.
+	 * Connects, waits until the session closes or `cancellation` is cancelled, and then disposes the
+	 * session and the transport stream.
 	 * @param cancellation optional cancellation token.
 	 */
 	public async connectAndRunUntilClosed(cancellation?: CancellationToken) {

--- a/src/ts/ssh/secureStream.ts
+++ b/src/ts/ssh/secureStream.ts
@@ -54,24 +54,20 @@ export class SecureStream extends Duplex implements Disposable {
 				encoding: BufferEncoding,
 				cb: (error?: Error | null) => void,
 			) {
-				if (!this.stream) throw new Error('Stream is not connected.');
-				return this.stream._write(chunk, encoding, cb);
+				return this.connectedStream._write(chunk, encoding, cb);
 			},
 			writev(
 				this: SecureStream,
 				chunks: { chunk: Buffer; encoding: BufferEncoding }[],
 				cb: (error?: Error | null) => void,
 			) {
-				if (!this.stream) throw new Error('Stream is not connected.');
-				return this.stream._writev!(chunks, cb);
+				return this.connectedStream._writev!(chunks, cb);
 			},
 			final(this: SecureStream, cb: (err?: Error | null) => void) {
-				if (!this.stream) throw new Error('Stream is not connected.');
-				return this.stream._final(cb);
+				return this.connectedStream._final(cb);
 			},
 			read(this: SecureStream, size: number) {
-				if (!this.stream) throw new Error('Stream is not connected.');
-				return this.stream?._read(size);
+				return this.connectedStream._read(size);
 			},
 		});
 
@@ -93,6 +89,11 @@ export class SecureStream extends Duplex implements Disposable {
 		this.session.onClosed(this.onSessionClosed, this, this.disposables);
 	}
 
+	private get connectedStream(): SshStream {
+		if (!this.stream) throw new Error('Stream is not connected.');
+		return this.stream;
+	}
+
 	public get trace(): Trace {
 		return this.session.trace;
 	}
@@ -100,12 +101,6 @@ export class SecureStream extends Duplex implements Disposable {
 	public set trace(trace: Trace) {
 		this.session.trace = trace;
 	}
-
-	/**
-	 * Gets or sets the maximum window size for channels within the multi-channel stream.
-	 * @see `SshChannel.maxWindowSize`
-	 */
-	public channelMaxWindowSize: number = SshChannel.defaultMaxWindowSize;
 
 	public get isClosed(): boolean {
 		return this.disposed || this.session.isClosed;

--- a/src/ts/ssh/secureStream.ts
+++ b/src/ts/ssh/secureStream.ts
@@ -1,0 +1,235 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//
+
+import { CancellationToken, Disposable, Emitter } from 'vscode-jsonrpc';
+import { Stream } from './streams';
+import { SshChannel } from './sshChannel';
+import { SshStream } from './sshStream';
+import { SshSession } from './sshSession';
+import { SshSessionConfiguration } from './sshSessionConfiguration';
+import { SshDisconnectReason } from './messages/transportMessages';
+import { SshSessionClosedEventArgs } from './events/sshSessionClosedEventArgs';
+import { Trace, TraceLevel, SshTraceEventIds } from './trace';
+import { ChannelOpenMessage } from './messages/connectionMessages';
+import { SshClientCredentials, SshServerCredentials } from './sshCredentials';
+import { SshClientSession } from './sshClientSession';
+import { SshServerSession } from './sshServerSession';
+import { SshAuthenticatingEventArgs } from './events/sshAuthenticatingEventArgs';
+import { SshConnectionError } from './errors';
+import { Duplex } from 'stream';
+
+/**
+ * Establishes an end-to-end encrypted two-way authenticated data stream over an underlying
+ * transport stream, using the SSH protocol but providing simplified interface that is limited to
+ * a single duplex stream (channel).
+ *
+ * This class is a complement to `MultiChannelStream`, which provides only the channel-multiplexing
+ * functions of SSH.
+ *
+ * To establish a secure connection, the two sides first establish an insecure transport stream
+ * over a pipe, socket, or anything else. Then they encrypt and authenticate the connection
+ * before beginning to send and receive data.
+ */
+export class SecureStream extends Duplex implements Disposable {
+	private readonly session: SshSession;
+	private readonly clientCredentials: SshClientCredentials | null = null;
+	private readonly serverCredentials: SshServerCredentials | null = null;
+	private stream?: SshStream;
+	private disposed: boolean = false;
+	private disposables: Disposable[] = [];
+
+	/**
+	 * Creates a new multi-channel stream over an underlying transport stream.
+	 * @param transportStream Stream that is used to multiplex all the channels.
+	 */
+	public constructor(
+		private readonly transportStream: Stream,
+		credentials: SshClientCredentials | SshServerCredentials,
+	) {
+		super({
+			write(
+				this: SecureStream,
+				chunk: Buffer | string | any,
+				encoding: BufferEncoding,
+				cb: (error?: Error | null) => void,
+			) {
+				if (!this.stream) throw new Error('Stream is not connected.');
+				return this.stream._write(chunk, encoding, cb);
+			},
+			writev(
+				this: SecureStream,
+				chunks: { chunk: Buffer; encoding: BufferEncoding }[],
+				cb: (error?: Error | null) => void,
+			) {
+				if (!this.stream) throw new Error('Stream is not connected.');
+				return this.stream._writev!(chunks, cb);
+			},
+			final(this: SecureStream, cb: (err?: Error | null) => void) {
+				if (!this.stream) throw new Error('Stream is not connected.');
+				return this.stream._final(cb);
+			},
+			read(this: SecureStream, size: number) {
+				if (!this.stream) throw new Error('Stream is not connected.');
+				return this.stream?._read(size);
+			},
+		});
+
+		if (!transportStream) throw new TypeError('A transport stream is required.');
+		if (!credentials) throw new TypeError('Client or server credentials are required.');
+
+		const sessionConfig = new SshSessionConfiguration(true);
+
+		if ('username' in credentials) {
+			this.clientCredentials = credentials;
+			this.session = new SshClientSession(sessionConfig);
+		} else if (credentials.publicKeys) {
+			this.serverCredentials = <SshServerCredentials>credentials;
+			this.session = new SshServerSession(sessionConfig);
+		} else {
+			throw new TypeError('Client or server credentials are required.');
+		}
+
+		this.session.onClosed(this.onSessionClosed, this, this.disposables);
+	}
+
+	public get trace(): Trace {
+		return this.session.trace;
+	}
+
+	public set trace(trace: Trace) {
+		this.session.trace = trace;
+	}
+
+	/**
+	 * Gets or sets the maximum window size for channels within the multi-channel stream.
+	 * @see `SshChannel.maxWindowSize`
+	 */
+	public channelMaxWindowSize: number = SshChannel.defaultMaxWindowSize;
+
+	public get isClosed(): boolean {
+		return this.disposed || this.session.isClosed;
+	}
+
+	private readonly closedEmitter = new Emitter<SshSessionClosedEventArgs>();
+	public readonly onClosed = this.closedEmitter.event;
+
+	public onAuthenticating(
+		listener: (e: SshAuthenticatingEventArgs) => any,
+		thisArgs?: any,
+		disposables?: Disposable[],
+	) {
+		return this.session.onAuthenticating(listener, thisArgs, disposables);
+	}
+
+	/**
+	 * Initiates the SSH session over the transport stream by exchanging initial messages with the
+	 * remote peer. Waits for the protocol version exchange and key exchange. Additional message
+	 * processing is kicked off as a background promise chain.
+	 * @param cancellation optional cancellation token.
+	 */
+	public async connect(cancellation?: CancellationToken) {
+		if (this.serverCredentials) {
+			const serverSession = <SshServerSession>this.session;
+			serverSession.credentials = this.serverCredentials;
+		}
+
+		await this.session.connect(this.transportStream, cancellation);
+
+		let channel: SshChannel | null = null;
+		if (this.clientCredentials) {
+			let error: SshConnectionError | null = null;
+			const clientSession = <SshClientSession>this.session;
+			if (!(await clientSession.authenticateServer(cancellation))) {
+				error = new SshConnectionError(
+					'Server authentication failed.',
+					SshDisconnectReason.hostKeyNotVerifiable,
+				);
+			}
+
+			if (
+				!error &&
+				!(await clientSession.authenticateClient(this.clientCredentials, cancellation))
+			) {
+				error = new SshConnectionError(
+					'Client authentication failed.',
+					SshDisconnectReason.noMoreAuthMethodsAvailable,
+				);
+			}
+
+			if (error) {
+				await this.session.close(error.reason!, error.message, error);
+				throw error;
+			}
+
+			channel = await this.session.openChannel(cancellation);
+		} else {
+			channel = await this.session.acceptChannel(cancellation);
+		}
+
+		this.stream = this.createStream(channel);
+		// Do not forward the 'readable' event because adding a listener causes a read.
+		this.stream.on('data', (data) => this.emit('data', data));
+		this.stream.on('end', () => this.emit('end'));
+		this.stream.on('close', () => this.emit('close'));
+		this.stream.on('error', () => this.emit('error'));
+		channel.onClosed(() => this.dispose());
+	}
+
+	/**
+	 * Creates a stream instance for a channel. May be overridden to create a `SshStream` subclass.
+	 */
+	protected createStream(channel: SshChannel): SshStream {
+		return new SshStream(channel);
+	}
+
+	public dispose() {
+		if (!this.disposed) {
+			this.disposed = true;
+			this.session.dispose();
+			this.unsubscribe();
+
+			try {
+				if (this.transportStream)
+					this.transportStream.close().catch((e) => {
+						this.trace(
+							TraceLevel.Error,
+							SshTraceEventIds.streamCloseError,
+							`Error closing transport stream: ${e.message}`,
+							e,
+						);
+					});
+			} catch (e) {
+				if (!(e instanceof Error)) throw e;
+				this.trace(
+					TraceLevel.Error,
+					SshTraceEventIds.streamCloseError,
+					`Error closing transport stream: ${e.message}`,
+					e,
+				);
+			}
+		}
+	}
+
+	public async close() {
+		if (!this.disposed) {
+			this.disposed = true;
+
+			await this.session.close(SshDisconnectReason.none, 'SshSession disposed');
+			this.session.dispose();
+			this.unsubscribe();
+
+			await this.transportStream.close();
+		}
+	}
+
+	private onSessionClosed(e: SshSessionClosedEventArgs) {
+		this.unsubscribe();
+		this.closedEmitter.fire(e);
+	}
+
+	private unsubscribe() {
+		this.disposables.forEach((d) => d.dispose());
+		this.disposables = [];
+	}
+}

--- a/src/ts/ssh/services/authenticationService.ts
+++ b/src/ts/ssh/services/authenticationService.ts
@@ -195,6 +195,8 @@ export class AuthenticationService extends SshService {
 		args: SshAuthenticatingEventArgs,
 		cancellation?: CancellationToken,
 	) {
+		args.cancellation = this.disposeCancellationSource.token;
+
 		let authenticatedPrincipal: object | null = null;
 		try {
 			authenticatedPrincipal = await (<any>this.session).raiseAuthenticatingEvent(args);
@@ -437,5 +439,14 @@ export class AuthenticationService extends SshService {
 		const signer = algorithm.createSigner(key);
 		const signature = await signer.sign(writer.toBuffer());
 		return algorithm.createSignatureData(signature);
+	}
+
+	public dispose() {
+		try {
+			this.disposeCancellationSource.cancel();
+			this.disposeCancellationSource.dispose();
+		} catch {}
+
+		super.dispose();
 	}
 }

--- a/src/ts/ssh/services/connectionService.ts
+++ b/src/ts/ssh/services/connectionService.ts
@@ -56,8 +56,19 @@ export class ConnectionService extends SshService {
 	}
 
 	public close(e: Error): void {
+		let channelCompletions = [...this.pendingChannels.values()].map((pc) => pc.completionSource);
+		if (this.pendingAcceptChannels.size > 0) {
+			channelCompletions = channelCompletions.concat(
+				[...this.pendingAcceptChannels.values()].reduce((a, b) => a.concat(b)),
+			);
+		}
+
 		for (let channel of this.channelMap.values()) {
 			channel.close(e);
+		}
+
+		for (let channelCompletion of channelCompletions) {
+			channelCompletion.reject(e);
 		}
 	}
 

--- a/src/ts/ssh/sshSession.ts
+++ b/src/ts/ssh/sshSession.ts
@@ -81,6 +81,7 @@ export class SshSession implements Disposable {
 	private readonly blockedMessagesSemaphore = new Semaphore(1);
 	private connected: boolean = false;
 	private disposed: boolean = false;
+	private closedError?: Error;
 
 	public get algorithms(): SshSessionAlgorithms | null {
 		return this.protocol ? this.protocol.algorithms : null;
@@ -1169,13 +1170,15 @@ export class SshSession implements Disposable {
 		}
 
 		this.disposed = true;
+		this.closedError = error;
 
+		error = error ?? new SshConnectionError(message, reason);
 		if (error) {
 			this.connectionService?.close(error);
 		}
 
 		this.closedEmitter.fire(
-			new SshSessionClosedEventArgs(reason, message || 'Disconnected.', error || null),
+			new SshSessionClosedEventArgs(reason, message || 'Disconnected.', error),
 		);
 
 		this.dispose();
@@ -1194,20 +1197,29 @@ export class SshSession implements Disposable {
 	}
 
 	private async handleDisconnectMessage(message: DisconnectMessage): Promise<void> {
-		await this.close(message.reasonCode ?? SshDisconnectReason.none, message.description);
+		const description = message.description || 'Received disconnect message.';
+		await this.close(message.reasonCode ?? SshDisconnectReason.none, description);
 	}
 
 	public dispose() {
+		const closedError =
+			this.closedError instanceof SshConnectionError
+				? this.closedError
+				: new SshConnectionError('Session disposed.');
 		if (!this.disposed) {
 			this.trace(TraceLevel.Info, SshTraceEventIds.sessionClosing, `${this} disposed.`);
 			this.disposed = true;
 			this.closedEmitter.fire(
-				new SshSessionClosedEventArgs(SshDisconnectReason.none, 'SshSession disposed', null),
+				new SshSessionClosedEventArgs(
+					SshDisconnectReason.none,
+					'SshSession disposed',
+					closedError,
+				),
 			);
 		}
 
 		if (this.requestHandler) {
-			this.requestHandler(new SshConnectionError('Connection closed.'));
+			this.requestHandler(closedError);
 		}
 
 		this.metrics.close();

--- a/test/cs/Ssh.Test/ChannelTests.cs
+++ b/test/cs/Ssh.Test/ChannelTests.cs
@@ -852,7 +852,10 @@ public class ChannelTests : IDisposable
 		channels.Client.Closed += (sender, e) => closedEvent = e;
 		await this.clientSession.CloseAsync(SshDisconnectReason.ByApplication);
 		Assert.NotNull(closedEvent);
-		Assert.Null(closedEvent.Exception);
+		Assert.IsType<SshConnectionException>(closedEvent.Exception);
+		Assert.Equal(
+			SshDisconnectReason.ByApplication,
+			((SshConnectionException)closedEvent.Exception).DisconnectReason);
 	}
 
 	[Fact]

--- a/test/cs/Ssh.Test/MultiChannelStreamTests.cs
+++ b/test/cs/Ssh.Test/MultiChannelStreamTests.cs
@@ -86,7 +86,10 @@ public class MultiChannelStreamTests
 			Assert.Equal(server, sender);
 			Assert.Equal(SshDisconnectReason.None, e.Reason);
 			Assert.Equal(typeof(SshSession).Name + " disposed", e.Message);
-			Assert.Null(e.Exception);
+			Assert.IsType<SshConnectionException>(e.Exception);
+			Assert.Equal(
+				SshDisconnectReason.None,
+				((SshConnectionException)e.Exception).DisconnectReason);
 			closedEventFired = true;
 		}
 	}

--- a/test/cs/Ssh.Test/SecureStreamTests.cs
+++ b/test/cs/Ssh.Test/SecureStreamTests.cs
@@ -1,0 +1,243 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Security.Claims;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.DevTunnels.Ssh.Algorithms;
+using Microsoft.DevTunnels.Ssh.Events;
+using Nerdbank.Streams;
+using Xunit;
+
+namespace Microsoft.DevTunnels.Ssh.Test;
+
+public class SecureStreamTests
+{
+	private static readonly TimeSpan Timeout = Debugger.IsAttached ?
+		TimeSpan.FromDays(1) : TimeSpan.FromSeconds(10);
+	private readonly CancellationToken TimeoutToken = new CancellationTokenSource(Timeout).Token;
+
+	private readonly IKeyPair serverKey;
+	private readonly IKeyPair clientKey;
+	private readonly SshServerCredentials serverCredentials;
+	private readonly SshClientCredentials clientCredentials;
+	private readonly Stream clientStream;
+	private readonly Stream serverStream;
+
+	public SecureStreamTests()
+	{
+		this.serverKey = SshAlgorithms.PublicKey.ECDsaSha2Nistp384.GenerateKeyPair();
+		this.serverCredentials = new SshServerCredentials(serverKey);
+		this.clientKey = SshAlgorithms.PublicKey.ECDsaSha2Nistp384.GenerateKeyPair();
+		this.clientCredentials = new SshClientCredentials("test", clientKey);
+
+		(this.serverStream, this.clientStream) = FullDuplexStream.CreatePair();
+	}
+
+	[Theory]
+	[InlineData(true)]
+	[InlineData(false)]
+	public async Task AuthenticateServer(bool authenticateSuccess)
+	{
+		var server = new SecureStream(this.serverStream, this.serverCredentials);
+		server.Authenticating += (_, e) =>
+			e.AuthenticationTask = Task.FromResult(new ClaimsPrincipal());
+
+		SshAuthenticatingEventArgs serverAuthenticatingEvent = null;
+		var client = new SecureStream(this.clientStream, this.clientCredentials);
+		client.Authenticating += (_, e) =>
+		{
+			serverAuthenticatingEvent = e;
+			e.AuthenticationTask = Task.FromResult(
+				authenticateSuccess ? new ClaimsPrincipal() : null);
+		};
+
+		var serverConnectTask = server.ConnectAsync(TimeoutToken);
+		var clientConnectTask = client.ConnectAsync(TimeoutToken);
+		try
+		{
+			await Task.WhenAll(serverConnectTask, clientConnectTask);
+		}
+		catch (Exception)
+		{
+			Assert.False(authenticateSuccess);
+		}
+
+		Assert.Equal(authenticateSuccess, serverConnectTask.IsCompletedSuccessfully);
+		Assert.Equal(authenticateSuccess, clientConnectTask.IsCompletedSuccessfully);
+		if (!authenticateSuccess)
+		{
+			var serverEx = await Assert.ThrowsAsync<SshConnectionException>(() => serverConnectTask);
+			Assert.Equal(SshDisconnectReason.HostKeyNotVerifiable, serverEx.DisconnectReason);
+
+			var clientEx = await Assert.ThrowsAsync<SshConnectionException>(() => clientConnectTask);
+			Assert.Equal(SshDisconnectReason.HostKeyNotVerifiable, clientEx.DisconnectReason);
+		}
+
+		Assert.Null(serverAuthenticatingEvent?.Username);
+		Assert.NotNull(serverAuthenticatingEvent?.PublicKey);
+		Assert.True(serverAuthenticatingEvent.PublicKey.GetPublicKeyBytes().Equals(
+			this.serverKey.GetPublicKeyBytes()));
+	}
+
+	[Theory]
+	[InlineData(true)]
+	[InlineData(false)]
+	public async Task AuthenticateClient(bool authenticateSuccess)
+	{
+		SshAuthenticatingEventArgs clientAuthenticatingEvent = null;
+		var server = new SecureStream(this.serverStream, this.serverCredentials);
+		server.Authenticating += (_, e) =>
+		{
+			clientAuthenticatingEvent = e;
+			e.AuthenticationTask = Task.FromResult(
+				authenticateSuccess ? new ClaimsPrincipal() : null);
+		};
+
+		var client = new SecureStream(this.clientStream, this.clientCredentials);
+		client.Authenticating += (_, e) =>
+			e.AuthenticationTask = Task.FromResult(new ClaimsPrincipal());
+
+		var serverConnectTask = server.ConnectAsync(TimeoutToken);
+		var clientConnectTask = client.ConnectAsync(TimeoutToken);
+		try
+		{
+			await Task.WhenAll(serverConnectTask, clientConnectTask);
+		}
+		catch (Exception)
+		{
+			Assert.False(authenticateSuccess);
+		}
+
+		Assert.Equal(authenticateSuccess, serverConnectTask.IsCompletedSuccessfully);
+		Assert.Equal(authenticateSuccess, clientConnectTask.IsCompletedSuccessfully);
+		if (!authenticateSuccess)
+		{
+			var serverEx = await Assert.ThrowsAsync<SshConnectionException>(() => serverConnectTask);
+			Assert.Equal(SshDisconnectReason.NoMoreAuthMethodsAvailable, serverEx.DisconnectReason);
+
+			var clientEx = await Assert.ThrowsAsync<SshConnectionException>(() => clientConnectTask);
+			Assert.Equal(SshDisconnectReason.NoMoreAuthMethodsAvailable, clientEx.DisconnectReason);
+		}
+
+		Assert.Equal(this.clientCredentials.Username, clientAuthenticatingEvent.Username);
+		Assert.NotNull(clientAuthenticatingEvent?.PublicKey);
+		Assert.True(clientAuthenticatingEvent.PublicKey.GetPublicKeyBytes().Equals(
+			this.clientKey.GetPublicKeyBytes()));
+	}
+
+	[Fact]
+	public async Task ReadWrite()
+	{
+		var (server, client) = await ConnectAsync();
+
+		await ExchangeDataAsync(server, client);
+
+		await server.CloseAsync();
+		await client.CloseAsync();
+	}
+
+	private async Task<(SecureStream Server, SecureStream Client)> ConnectAsync()
+	{
+		var server = new SecureStream(this.serverStream, this.serverCredentials);
+		server.Authenticating += (_, e) =>
+			e.AuthenticationTask = Task.FromResult(new ClaimsPrincipal());
+		var client = new SecureStream(this.clientStream, this.clientCredentials);
+		client.Authenticating += (_, e) =>
+			e.AuthenticationTask = Task.FromResult(new ClaimsPrincipal());
+
+		await Task.WhenAll(server.ConnectAsync(TimeoutToken), client.ConnectAsync(TimeoutToken));
+
+		return (server, client);
+	}
+
+	private static async Task ExchangeDataAsync(SecureStream server, SecureStream client)
+	{
+		const string payloadString = "Hello!";
+		byte[] payload = Encoding.UTF8.GetBytes(payloadString);
+		byte[] result = new byte[100];
+
+		// Write from client, read from server
+		await client.WriteAsync(payload, 0, payload.Length);
+		int resultCount = await server.ReadAsync(result, 0, result.Length);
+		Assert.Equal(payload.Length, resultCount);
+		Assert.Equal(payloadString, Encoding.UTF8.GetString(result, 0, resultCount));
+
+		// Write from server, read from client
+		await server.WriteAsync(payload, 0, payload.Length);
+		resultCount = await client.ReadAsync(result, 0, result.Length);
+		Assert.Equal(payload.Length, resultCount);
+		Assert.Equal(payloadString, Encoding.UTF8.GetString(result, 0, resultCount));
+	}
+
+	[Theory]
+	[InlineData(true)]
+	[InlineData(false)]
+	public async Task DisposeClosesTransportStream(bool disposeAsync)
+	{
+		var stream = new MemoryStream();
+
+		var server = new SecureStream(stream, this.serverCredentials);
+		Assert.False(server.IsClosed);
+		var closedEventRaised = false;
+		server.Closed += (_, _) => closedEventRaised = true;
+
+		await DisposeSecureStreamAsync(server, disposeAsync);
+		Assert.True(server.IsClosed);
+		Assert.True(closedEventRaised);
+
+		// The transport stream should have been disposed.
+		Assert.Throws<ObjectDisposedException>(() => stream.WriteByte(0));
+	}
+
+	private async ValueTask DisposeSecureStreamAsync(SecureStream stream, bool disposeAsync)
+	{
+		if (disposeAsync)
+		{
+			await stream.CloseAsync();
+		}
+		else
+		{
+			stream.Dispose();
+		}
+	}
+
+	[Theory]
+	[InlineData(true, true)]
+	[InlineData(true, false)]
+	[InlineData(false, true)]
+	[InlineData(false, false)]
+	public async Task DisposeRaisesCloseEvent(bool isConnected, bool disposeAsync)
+	{
+		var server = new SecureStream(this.serverStream, this.serverCredentials);
+		server.Authenticating += (_, e) =>
+			e.AuthenticationTask = Task.FromResult(new ClaimsPrincipal());
+
+		using var client = new SecureStream(this.clientStream, this.clientCredentials);
+		client.Authenticating += (_, e) =>
+			e.AuthenticationTask = Task.FromResult(new ClaimsPrincipal());
+
+		var closedEventRaised = false;
+		server.Closed += (sender, e) =>
+		{
+			Assert.Equal(server, sender);
+			Assert.Equal(SshDisconnectReason.None, e.Reason);
+			Assert.Equal(typeof(SshServerSession).Name + " disposed", e.Message);
+			closedEventRaised = true;
+		};
+
+		if (isConnected)
+		{
+			await Task.WhenAll(
+				client.ConnectAsync(TimeoutToken),
+				server.ConnectAsync(TimeoutToken));
+		}
+
+		await DisposeSecureStreamAsync(server, disposeAsync);
+
+		Assert.True(server.IsClosed);
+		Assert.True(closedEventRaised);
+	}
+}

--- a/test/cs/Ssh.Test/SessionTests.cs
+++ b/test/cs/Ssh.Test/SessionTests.cs
@@ -70,9 +70,17 @@ public class SessionTests : IDisposable
 			this.clientClosedSemaphore.WaitAsync()).WithTimeout(Timeout);
 
 		Assert.NotNull(this.serverClosedEvent);
-		Assert.Null(this.serverClosedEvent.Exception);
+		Assert.Equal(SshDisconnectReason.ConnectionLost, this.serverClosedEvent.Reason);
+		Assert.IsType<SshConnectionException>(this.serverClosedEvent.Exception);
+		Assert.Equal(
+			SshDisconnectReason.ConnectionLost,
+			((SshConnectionException)this.serverClosedEvent.Exception).DisconnectReason);
 		Assert.NotNull(this.clientClosedEvent);
-		Assert.Null(this.clientClosedEvent.Exception);
+		Assert.Equal(SshDisconnectReason.ConnectionLost, this.clientClosedEvent.Reason);
+		Assert.IsType<SshConnectionException>(this.clientClosedEvent.Exception);
+		Assert.Equal(
+			SshDisconnectReason.ConnectionLost,
+			((SshConnectionException)this.clientClosedEvent.Exception).DisconnectReason);
 	}
 
 	[Fact]
@@ -88,7 +96,10 @@ public class SessionTests : IDisposable
 
 		Assert.NotNull(this.clientClosedEvent);
 		Assert.Equal(TestDisconnectReason, this.clientClosedEvent.Reason);
-		Assert.Null(this.clientClosedEvent.Exception);
+		Assert.IsType<SshConnectionException>(this.clientClosedEvent.Exception);
+		Assert.Equal(
+			TestDisconnectReason,
+			((SshConnectionException)this.clientClosedEvent.Exception).DisconnectReason);
 	}
 
 	[Fact]
@@ -104,7 +115,10 @@ public class SessionTests : IDisposable
 
 		Assert.NotNull(this.serverClosedEvent);
 		Assert.Equal(TestDisconnectReason, this.serverClosedEvent.Reason);
-		Assert.Null(this.serverClosedEvent.Exception);
+		Assert.IsType<SshConnectionException>(this.clientClosedEvent.Exception);
+		Assert.Equal(
+			TestDisconnectReason,
+			((SshConnectionException)this.clientClosedEvent.Exception).DisconnectReason);
 	}
 
 	private void OnSessionAuthenticating(object sender, SshAuthenticatingEventArgs e) =>

--- a/test/ts/ssh-test/channelTests.ts
+++ b/test/ts/ssh-test/channelTests.ts
@@ -20,6 +20,7 @@ import {
 	PromiseCompletionSource,
 	SshChannelOpeningEventArgs,
 	ChannelOpenMessage,
+	SshConnectionError,
 } from '@microsoft/dev-tunnels-ssh';
 import { shutdownWebSocketServer } from './duplexStream';
 import {
@@ -615,7 +616,11 @@ export class ChannelTests {
 		});
 		await clientSession.close(SshDisconnectReason.byApplication, 'test');
 		assert(closedEvent);
-		assert(!closedEvent!.error);
+		assert(closedEvent!.error instanceof SshConnectionError);
+		assert.equal(
+			(<SshConnectionError>closedEvent!.error).reason,
+			SshDisconnectReason.byApplication,
+		);
 	}
 
 	@test

--- a/test/ts/ssh-test/secureStreamTests.ts
+++ b/test/ts/ssh-test/secureStreamTests.ts
@@ -1,0 +1,293 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//
+
+import * as assert from 'assert';
+import { suite, test, params, slow, timeout, pending } from '@testdeck/mocha';
+import { DuplexStream } from './duplexStream';
+
+import {
+	KeyPair,
+	PromiseCompletionSource,
+	SecureStream,
+	SshAlgorithms,
+	SshAuthenticatingEventArgs,
+	SshClientCredentials,
+	SshConnectionError,
+	SshDisconnectReason,
+	SshServerCredentials,
+} from '@microsoft/dev-tunnels-ssh';
+
+@suite
+@slow(3000)
+@timeout(20000)
+export class SecureStreamTests {
+	private static clientKey: KeyPair;
+	private static serverKey: KeyPair;
+	private static clientCredentials: SshClientCredentials;
+	private static serverCredentials: SshServerCredentials;
+
+	@slow(10000)
+	@timeout(20000)
+	public static async before() {
+		SecureStreamTests.clientKey = await SshAlgorithms.publicKey.rsaWithSha512!.generateKeyPair();
+		SecureStreamTests.serverKey = await SshAlgorithms.publicKey.rsaWithSha512!.generateKeyPair();
+
+		SecureStreamTests.clientCredentials = {
+			username: 'test',
+			publicKeys: [SecureStreamTests.clientKey],
+		};
+		SecureStreamTests.serverCredentials = { publicKeys: [SecureStreamTests.serverKey] };
+	}
+
+	@test
+	@params({ authenticateSuccess: true })
+	@params({ authenticateSuccess: false })
+	@params.naming((p) => `authenticateServer(authenticateSuccess:${p.authenticateSuccess})`)
+	public async authenticateServer({ authenticateSuccess }: { authenticateSuccess: boolean }) {
+		const [serverStream, clientStream] = await DuplexStream.createStreams();
+
+		const server = new SecureStream(serverStream, SecureStreamTests.serverCredentials);
+		server.onAuthenticating((e) => (e.authenticationPromise = Promise.resolve({})));
+
+		let serverAuthenticatingEvent: SshAuthenticatingEventArgs | null = null;
+		const client = new SecureStream(clientStream, SecureStreamTests.clientCredentials);
+		client.onAuthenticating((e) => {
+			serverAuthenticatingEvent = e;
+			e.authenticationPromise = Promise.resolve(authenticateSuccess ? {} : null);
+		});
+
+		const serverConnectPromise = server.connect();
+		const clientConnectPromise = client.connect();
+
+		try {
+			await Promise.all([serverConnectPromise, clientConnectPromise]);
+		} catch {
+			assert(!authenticateSuccess);
+		}
+
+		if (!authenticateSuccess) {
+			let serverError: Error | null = null;
+			try {
+				await serverConnectPromise;
+			} catch (e) {
+				serverError = e instanceof Error ? e : null;
+			}
+			assert(serverError instanceof SshConnectionError);
+			assert.equal(
+				(<SshConnectionError>serverError).reason,
+				SshDisconnectReason.hostKeyNotVerifiable,
+			);
+
+			let clientError: Error | null = null;
+			try {
+				await clientConnectPromise;
+			} catch (e) {
+				clientError = e instanceof Error ? e : null;
+			}
+			assert(clientError instanceof SshConnectionError);
+			assert.equal(
+				(<SshConnectionError>clientError).reason,
+				SshDisconnectReason.hostKeyNotVerifiable,
+			);
+		}
+
+		assert(serverAuthenticatingEvent);
+		assert.strictEqual(serverAuthenticatingEvent!.username, null);
+		assert(serverAuthenticatingEvent!.publicKey);
+		assert(
+			(await serverAuthenticatingEvent!.publicKey!.getPublicKeyBytes())!.equals(
+				(await SecureStreamTests.serverKey.getPublicKeyBytes())!,
+			),
+		);
+	}
+
+	@test
+	@params({ authenticateSuccess: true })
+	@params({ authenticateSuccess: false })
+	@params.naming((p) => `authenticateClient(authenticateSuccess:${p.authenticateSuccess})`)
+	public async authenticateClient({ authenticateSuccess }: { authenticateSuccess: boolean }) {
+		const [serverStream, clientStream] = await DuplexStream.createStreams();
+
+		let clientAuthenticatingEvent: SshAuthenticatingEventArgs | null = null;
+		const server = new SecureStream(serverStream, SecureStreamTests.serverCredentials);
+		server.onAuthenticating((e) => {
+			clientAuthenticatingEvent = e;
+			e.authenticationPromise = Promise.resolve(authenticateSuccess ? {} : null);
+		});
+
+		const client = new SecureStream(clientStream, SecureStreamTests.clientCredentials);
+		client.onAuthenticating((e) => (e.authenticationPromise = Promise.resolve({})));
+
+		const serverConnectPromise = server.connect();
+		const clientConnectPromise = client.connect();
+
+		try {
+			await Promise.all([serverConnectPromise, clientConnectPromise]);
+		} catch {
+			assert(!authenticateSuccess);
+		}
+
+		if (!authenticateSuccess) {
+			let serverError: Error | null = null;
+			try {
+				await serverConnectPromise;
+			} catch (e) {
+				serverError = e instanceof Error ? e : null;
+			}
+			assert(serverError instanceof SshConnectionError);
+			assert.equal(
+				(<SshConnectionError>serverError).reason,
+				SshDisconnectReason.noMoreAuthMethodsAvailable,
+			);
+
+			let clientError: Error | null = null;
+			try {
+				await clientConnectPromise;
+			} catch (e) {
+				clientError = e instanceof Error ? e : null;
+			}
+			assert(clientError instanceof SshConnectionError);
+			assert.equal(
+				(<SshConnectionError>clientError).reason,
+				SshDisconnectReason.noMoreAuthMethodsAvailable,
+			);
+		}
+
+		assert(clientAuthenticatingEvent);
+		assert.equal(
+			clientAuthenticatingEvent!.username,
+			SecureStreamTests.clientCredentials.username,
+		);
+		assert(clientAuthenticatingEvent!.publicKey);
+		assert(
+			(await clientAuthenticatingEvent!.publicKey!.getPublicKeyBytes())!.equals(
+				(await SecureStreamTests.clientKey.getPublicKeyBytes())!,
+			),
+		);
+	}
+
+	@test
+	@params({ disposeAsync: true })
+	@params({ disposeAsync: false })
+	@params.naming((p) => `disposeClosesTransportStream(disposeAsync:${p.disposeAsync})`)
+	public async disposeClosesTransportStream({ disposeAsync }: { disposeAsync: boolean }) {
+		const [_, serverStream] = await DuplexStream.createStreams();
+		const server = new SecureStream(serverStream, SecureStreamTests.serverCredentials);
+		assert(!server.isClosed);
+
+		let closedEventRaised = false;
+		server.onClosed((e) => (closedEventRaised = true));
+
+		await SecureStreamTests.disposeSecureStream(server, disposeAsync);
+
+		assert(server.isClosed);
+		assert(closedEventRaised);
+		assert(serverStream.isDisposed);
+	}
+
+	@test
+	@params({ isConnected: true, disposeAsync: true })
+	@params({ isConnected: true, disposeAsync: false })
+	@params({ isConnected: false, disposeAsync: true })
+	@params({ isConnected: false, disposeAsync: false })
+	@params.naming(
+		(p) =>
+			`disposeClosesTransportStream(isConnected:${p.isConnected},disposeAsync:${p.disposeAsync})`,
+	)
+	public async disposeRaisesCloseEvent({
+		isConnected,
+		disposeAsync,
+	}: {
+		isConnected: boolean;
+		disposeAsync: boolean;
+	}) {
+		const [server, client] = await this.connect();
+
+		let closedEventRaised = false;
+		server.onClosed((e) => {
+			assert.equal(e.reason, SshDisconnectReason.none);
+			assert.equal(e.message, 'SshSession disposed');
+			closedEventRaised = true;
+		});
+
+		if (isConnected) {
+			await Promise.all([client.connect(), server.connect()]);
+		}
+
+		await SecureStreamTests.disposeSecureStream(server, disposeAsync);
+
+		assert(server.isClosed);
+		assert(closedEventRaised);
+	}
+
+	private static async disposeSecureStream(stream: SecureStream, disposeAsync: boolean) {
+		if (disposeAsync) {
+			await stream.close();
+		} else {
+			stream.dispose();
+		}
+	}
+
+	@test
+	public async readWrite() {
+		const [server, client] = await this.connect();
+
+		await this.exchangeData(server, client);
+
+		await server.close();
+		await client.close();
+	}
+
+	private async connect(): Promise<[SecureStream, SecureStream]> {
+		const [serverStream, clientStream] = await DuplexStream.createStreams();
+
+		const server = new SecureStream(serverStream, SecureStreamTests.serverCredentials);
+		server.onAuthenticating((e) => (e.authenticationPromise = Promise.resolve({})));
+		const client = new SecureStream(clientStream, SecureStreamTests.clientCredentials);
+		client.onAuthenticating((e) => (e.authenticationPromise = Promise.resolve({})));
+
+		await Promise.all([server.connect(), client.connect()]);
+
+		return [server, client];
+	}
+
+	private async exchangeData(server: SecureStream, client: SecureStream) {
+		const payloadString = 'Hello!';
+		const payload = Buffer.from(payloadString, 'utf8');
+
+		// Write from client, read from server.
+		const readPromise = readAsync(server);
+		await writeAsync(client, payload);
+		const result1 = await readPromise;
+		assert.equal(result1.toString('utf8'), payloadString);
+
+		// Write from server, read from client.
+		await writeAsync(server, payload);
+		const result2 = await readAsync(client);
+		assert.equal(result2.toString('utf8'), payloadString);
+	}
+}
+
+async function writeAsync(writable: NodeJS.WritableStream, chunk: Buffer): Promise<void> {
+	return new Promise<void>((resolve, reject) => {
+		writable.write(chunk, (err) => {
+			if (err) {
+				reject(err);
+			} else {
+				resolve();
+			}
+		});
+	});
+}
+
+async function readAsync(readable: NodeJS.ReadableStream): Promise<Buffer> {
+	return new Promise<Buffer>((resolve, reject) => {
+		readable.once('data', (data) => {
+			resolve(data);
+		});
+		readable.once('error', (e) => {
+			reject(e);
+		});
+	});
+}


### PR DESCRIPTION
Adding `SecureStream`, which provides an end-to-end encrypted two-way authenticated data stream over an underlying transport stream, using the SSH protocol but providing a simplified interface limited to a single duplex stream (channel). It is a complement to `MultiChannelStream`, which is a simplified interface to only the channel-multiplexing part of SSH.

This change also includes some improvements to session and channel close/dispose behaviors.