### PR TITLE
Skip CodeQL for mac job in CI build

### DIFF
--- a/.pipelines/dev-tunnels-ssh-ci.yaml
+++ b/.pipelines/dev-tunnels-ssh-ci.yaml
@@ -217,6 +217,9 @@ jobs:
     timeoutInMinutes: 90
     pool:
       vmImage: internal-macOS-11
+    variables:
+      - name: Codeql.SkipTaskAutoInjection
+        value: true
     steps:
       - checkout: self
         fetchDepth: -1


### PR DESCRIPTION
The two stages of the CI build pipeline build the same code and so we only need to do CodeQl in one of them.