### PR TITLE
Fix port-forward response message sequencing

### DIFF
--- a/src/cs/Ssh/Events/SshRequestEventArgs.cs
+++ b/src/cs/Ssh/Events/SshRequestEventArgs.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 
+using System;
 using System.Diagnostics;
 using System.Security.Claims;
 using System.Threading;
@@ -62,6 +63,16 @@ public class SshRequestEventArgs<T> where T : SshMessage
 	/// success or failure message.
 	/// </remarks>
 	public Task<SshMessage>? ResponseTask { get; set; }
+
+	/// <summary>
+	/// Gets or sets an action to be invoked AFTER any response message has been sent.
+	/// (The continuation will be invoked even if a response was not requested.)
+	/// </summary>
+	/// <remarks>
+	/// This enables a request handler to ensure additional messages are sequenced after the
+	/// response message.
+	/// </remarks>
+	public Func<Task>? ResponseContinuation { get; set; }
 
 	/// <summary>
 	/// Gets a token that is cancelled if the session ends before the async response task

--- a/src/cs/Ssh/Events/SshRequestEventArgs.cs
+++ b/src/cs/Ssh/Events/SshRequestEventArgs.cs
@@ -72,7 +72,7 @@ public class SshRequestEventArgs<T> where T : SshMessage
 	/// This enables a request handler to ensure additional messages are sequenced after the
 	/// response message.
 	/// </remarks>
-	public Func<Task>? ResponseContinuation { get; set; }
+	public Func<SshMessage, Task>? ResponseContinuation { get; set; }
 
 	/// <summary>
 	/// Gets a token that is cancelled if the session ends before the async response task

--- a/src/cs/Ssh/Messages/SshMessage.cs
+++ b/src/cs/Ssh/Messages/SshMessage.cs
@@ -27,7 +27,9 @@ public abstract class SshMessage
 
 	public abstract byte MessageType { get; }
 
+#pragma warning disable CA2227 // Change to read-only by removing the property setter
 	protected Buffer RawBytes { get; set; }
+#pragma warning restore CA2227
 
 	public void Read(ref SshDataReader reader)
 	{

--- a/src/cs/Ssh/SshChannel.cs
+++ b/src/cs/Ssh/SshChannel.cs
@@ -440,6 +440,7 @@ public class SshChannel : IDisposable
 				}
 			}
 
+			Func<Task>? continuation = args.ResponseContinuation;
 			if (sshRequestArgs.Request.WantReply)
 			{
 				if (sshRequestArgs.IsAuthorized)
@@ -458,6 +459,11 @@ public class SshChannel : IDisposable
 				}
 
 				await Session.SendMessageAsync(response!, cancellation).ConfigureAwait(false);
+			}
+
+			if (continuation != null)
+			{
+				await continuation().ConfigureAwait(false);
 			}
 		};
 

--- a/src/cs/Ssh/SshChannel.cs
+++ b/src/cs/Ssh/SshChannel.cs
@@ -164,7 +164,7 @@ public class SshChannel : IDisposable
 	/// <see cref="SshSession.OpenChannelAsync(ChannelOpenMessage, ChannelRequestMessage?, CancellationToken)"/>,
 	/// or for a channel opened by the other side by assigning to this property while handling the
 	/// <see cref="SshSession.ChannelOpening"/> event. Changing the maximum window size at any
-	/// other time is not valid because the other side would not be aware of the change. 
+	/// other time is not valid because the other side would not be aware of the change.
 	/// </remarks>
 	public uint MaxWindowSize
 	{
@@ -440,30 +440,30 @@ public class SshChannel : IDisposable
 				}
 			}
 
-			Func<Task>? continuation = args.ResponseContinuation;
-			if (sshRequestArgs.Request.WantReply)
+			if (sshRequestArgs.IsAuthorized)
 			{
-				if (sshRequestArgs.IsAuthorized)
+				response ??= new ChannelSuccessMessage();
+				((ChannelSuccessMessage)response).RecipientChannel = RemoteChannelId;
+			}
+			else
+			{
+				if (!(response is ChannelFailureMessage))
 				{
-					response ??= new ChannelSuccessMessage();
-					((ChannelSuccessMessage)response).RecipientChannel = RemoteChannelId;
-				}
-				else
-				{
-					if (!(response is ChannelFailureMessage))
-					{
-						response = new ChannelFailureMessage();
-					}
-
-					((ChannelFailureMessage)response).RecipientChannel = RemoteChannelId;
+					response = new ChannelFailureMessage();
 				}
 
-				await Session.SendMessageAsync(response!, cancellation).ConfigureAwait(false);
+				((ChannelFailureMessage)response).RecipientChannel = RemoteChannelId;
 			}
 
+			if (sshRequestArgs.Request.WantReply)
+			{
+				await Session.SendMessageAsync(response, cancellation).ConfigureAwait(false);
+			}
+
+			Func<SshMessage, Task>? continuation = args.ResponseContinuation;
 			if (continuation != null)
 			{
-				await continuation().ConfigureAwait(false);
+				await continuation(response).ConfigureAwait(false);
 			}
 		};
 

--- a/src/cs/Ssh/TaskChain.cs
+++ b/src/cs/Ssh/TaskChain.cs
@@ -60,7 +60,7 @@ internal class TaskChain : IDisposable
 
 			if (runInSequenceTask == null)
 			{
-				runInSequenceTask = Task.Run(
+				runInSequenceTask = Task.Factory.StartNew(
 					async () =>
 					{
 						try
@@ -73,7 +73,9 @@ internal class TaskChain : IDisposable
 							onError(ex);
 						}
 					},
-					cancellation);
+					cancellation,
+					TaskCreationOptions.None,
+					TaskScheduler.Default);
 			}
 			else
 			{

--- a/test/ts/ssh-test/portForwardingTests.ts
+++ b/test/ts/ssh-test/portForwardingTests.ts
@@ -979,7 +979,7 @@ export class PortForwardingTests {
 			const acceptPromise = acceptSocketConnection(localServer);
 
 			const waitPromise = serverPfs.waitForForwardedPort(testPort);
-			const forwarder = await withTimeout(
+			const forwardPromise = await withTimeout(
 				clientPfs.forwardFromRemotePort(loopbackV4, testPort),
 				timeoutMs,
 			);
@@ -990,6 +990,11 @@ export class PortForwardingTests {
 				timeoutMs,
 			);
 			const localClient = await withTimeout(acceptPromise, timeoutMs);
+
+			// Don't wait for the forward response until after connecting.
+			// The side that receives the forward request can open a port-forwarding channel
+			// immediately (before the request sender has received the response).
+			await forwardPromise;
 		} finally {
 			localServer.close();
 		}


### PR DESCRIPTION
When a `PortForwardRequestMessage` is received, the recipient may attempt to immediately open a channel on the newly forwarded port. There was a timing bug in which the `ChannelOpenMessage` could be sent _before_ the `PortForwardSuccessMessage`, and that would cause the other side to reject the channel.

I reproduced the issue by modifying a test case, and fixed it by adding a response continuation mechanism for request events. The `PortForwardingService` uses a response continuation to ensure the port-added event is raised after sending the response, therefore any handler of the port-added event can safely open a channel.

The problem only existed in C#. While TS code follows the same pattern, there was no issue due to the way JS events are raised asynchronously.

Fixes: https://github.com/microsoft/basis-planning/issues/605