### PR TITLE
Fix an issue when importing ssh-keys package

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,12 @@ cannot access native TCP sockets, the standard use of SSH over TCP is not possib
 some other stream transport like a websocket may be used. For details about the
 TypeScript library, see [src/ts/ssh/README.md](./src/ts/ssh/README.md).
 
+### Limitations
+The following features are not implemented in typescript implementation yet, and we have
+plans to implement the same:
+- Async processing of messages and ability to send one message before receiving response
+  for a previous one.
+
 ## Packages
 
 |                                          | C# NuGet package | TS npm package |

--- a/README.md
+++ b/README.md
@@ -67,12 +67,6 @@ cannot access native TCP sockets, the standard use of SSH over TCP is not possib
 some other stream transport like a websocket may be used. For details about the
 TypeScript library, see [src/ts/ssh/README.md](./src/ts/ssh/README.md).
 
-### Limitations
-The following features are not implemented in typescript implementation yet, and we have
-plans to implement the same:
-- Async processing of messages and ability to send one message before receiving response
-  for a previous one.
-
 ## Packages
 
 |                                          | C# NuGet package | TS npm package |

--- a/src/ts/ssh-keys/jsonWebKeyFormatter.ts
+++ b/src/ts/ssh-keys/jsonWebKeyFormatter.ts
@@ -2,10 +2,17 @@
 //  Copyright (c) Microsoft Corporation. All rights reserved.
 //
 
-import { SshAlgorithms, KeyPair, Rsa, RsaParameters, BigInt } from '@microsoft/dev-tunnels-ssh';
+import {
+	SshAlgorithms,
+	KeyPair,
+	Rsa,
+	RsaParameters,
+	BigInt,
+	ECDsa,
+	ECParameters,
+} from '@microsoft/dev-tunnels-ssh';
 import { KeyFormatter } from './keyFormatter';
 import { KeyData } from './keyData';
-import { ECDsa, ECParameters } from '../ssh/algorithms/sshAlgorithms';
 
 interface CommentedJwk extends JsonWebKey {
 	comment?: string;

--- a/src/ts/ssh/README.md
+++ b/src/ts/ssh/README.md
@@ -13,6 +13,12 @@ and browser environments.
  - Supports reconnecting a disconnected session without disrupting channel streams.
  - Compatible with common SSH software. (Tested against OpenSSH.)
 
+### Limitations
+The following features are not implemented in typescript implementation yet, and we have
+plans to implement the same:
+- Async processing of messages and ability to send one message before receiving response
+  for a previous one.
+
 ## Requirements
 The TypeScript implementation supports either Node.js (>= 8.x) or a
 browser environment. When running on Node.js, it uses the Node.js built-in


### PR DESCRIPTION
We were getting an error similar to `Cannot find module '../ssh/algorithms/sshAlgorithms'`
Add additional information for typescript - Async processing of messages in TS-SDK not implemented yet for parity