### PR TITLE
Update vscode-jsonrpc dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
 			"dependencies": {
 				"buffer": "^5.2.1",
 				"diffie-hellman": "^5.0.3",
-				"vscode-jsonrpc": "^4.0.0"
+				"vscode-jsonrpc": "^8.0.2"
 			},
 			"devDependencies": {
 				"@testdeck/mocha": "^0.1.0",
@@ -4879,11 +4879,11 @@
 			"dev": true
 		},
 		"node_modules/vscode-jsonrpc": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-4.0.0.tgz",
-			"integrity": "sha512-perEnXQdQOJMTDFNv+UF3h1Y0z4iSiaN9jIlb0OqIYgosPCZGYh/MCUlkFtV2668PL69lRDO32hmvL2yiidUYg==",
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.0.2.tgz",
+			"integrity": "sha512-RY7HwI/ydoC1Wwg4gJ3y6LpU9FJRZAUnTYMXthqhFXXu77ErDd/xkREpGuk4MyYkk4a+XDWAMqe0S3KkelYQEQ==",
 			"engines": {
-				"node": ">=8.0.0 || >=10.0.0"
+				"node": ">=14.0.0"
 			}
 		},
 		"node_modules/websocket": {
@@ -9064,9 +9064,9 @@
 			"dev": true
 		},
 		"vscode-jsonrpc": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-4.0.0.tgz",
-			"integrity": "sha512-perEnXQdQOJMTDFNv+UF3h1Y0z4iSiaN9jIlb0OqIYgosPCZGYh/MCUlkFtV2668PL69lRDO32hmvL2yiidUYg=="
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.0.2.tgz",
+			"integrity": "sha512-RY7HwI/ydoC1Wwg4gJ3y6LpU9FJRZAUnTYMXthqhFXXu77ErDd/xkREpGuk4MyYkk4a+XDWAMqe0S3KkelYQEQ=="
 		},
 		"websocket": {
 			"version": "1.0.34",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
 	"dependencies": {
 		"buffer": "^5.2.1",
 		"diffie-hellman": "^5.0.3",
-		"vscode-jsonrpc": "^4.0.0"
+		"vscode-jsonrpc": "^8.0.2"
 	},
 	"devDependencies": {
 		"@testdeck/mocha": "^0.1.0",

--- a/test/ts/ssh-test/channelTests.ts
+++ b/test/ts/ssh-test/channelTests.ts
@@ -30,7 +30,7 @@ import {
 	authenticateServer,
 } from './sessionPair';
 import { CancellationTokenSource } from 'vscode-jsonrpc';
-import { withTimeout } from './promiseUtils';
+import { until, withTimeout } from './promiseUtils';
 
 @suite
 @slow(3000)
@@ -284,7 +284,7 @@ export class ChannelTests {
 		await serverChannelTask;
 
 		// Wait for the request to be received by the server.
-		await new Promise((c) => setImmediate(c));
+		await until(async () => !!serverRequest, 5000);
 
 		assert(serverRequest);
 		assert.equal(testRequestType, serverRequest!.requestType);

--- a/test/ts/ssh-test/test.html
+++ b/test/ts/ssh-test/test.html
@@ -3,11 +3,11 @@
 	<head>
 		<meta charset="utf-8" />
 		<title>SSH Tests</title>
-		<link rel="stylesheet" href="https://unpkg.com/mocha/mocha.css" />
+		<link rel="stylesheet" href="https://unpkg.com/mocha@9.2.2/mocha.css" />
 	</head>
 	<body>
 		<div id="mocha"></div>
-		<script src="https://unpkg.com/mocha/mocha.js"></script>
+		<script src="https://unpkg.com/mocha@9.2.2/mocha.js"></script>
 		<script class="mocha-init">
 			mocha.setup('bdd');
 			mocha.checkLeaks();


### PR DESCRIPTION
- Update `vscode-jsonrpc` package dependency from v4 to v8, to resolve some browser compatibility issues in v4. I ran tests covering usage of this library in both Node.js and browser environments to confirm there are no breaking changes.

- Fix a browser-specific bug in an unrelated test - that test case was added recently without testing in a browser.

- Add mocha version to `unpkg.com` URL in the test file. The service starting returning 500 status when requesting packages without a version, anyway it's better to match the version of mocha installed locally.