### PR TITLE
Fix build errors from vscode-jsonrpc update

### DIFF
--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -34,7 +34,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: '12.x'
+          node-version: '14.x'
 
       - name: Restore npm packages
         run: npm install

--- a/.pipelines/dev-tunnels-ssh-ci.yaml
+++ b/.pipelines/dev-tunnels-ssh-ci.yaml
@@ -70,9 +70,9 @@ jobs:
           nugetConfigPath: NuGet.config
 
       - task: NodeTool@0
-        displayName: Use Node 12.x
+        displayName: Use Node 14.x
         inputs:
-          versionSpec: 12.x
+          versionSpec: 14.x
 
       - task: Npm@1
         displayName: Restore npm packages
@@ -258,9 +258,9 @@ jobs:
           nugetConfigPath: NuGet.config
 
       - task: NodeTool@0
-        displayName: Use Node 12.x
+        displayName: Use Node 14.x
         inputs:
-          versionSpec: 12.x
+          versionSpec: 14.x
 
       - task: Npm@1
         displayName: Restore npm packages

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Windows or .NET Core 2.0+ on any platform. It's tested on Windows, Mac, & Ubuntu
 details about the .NET library, see [src/cs/Ssh/README.md](./src/cs/Ssh/README.md).
 
 ## TypeScript (Node.js or Browser)
-The TypeScript implementation supports either Node.js (>= 8.x) or a browser
+The TypeScript implementation supports either Node.js (>= 14.x) or a browser
 environment. The Node.js version is tested on Windows, Mac & Unbuntu; the browser
 version is tested on Chrome & Edge Chromium, though it should work in any modern
 browser that supports the web crypto API. Note that since script on a web page

--- a/src/ts/ssh/README.md
+++ b/src/ts/ssh/README.md
@@ -20,7 +20,7 @@ plans to implement the same:
   for a previous one.
 
 ## Requirements
-The TypeScript implementation supports either Node.js (>= 8.x) or a
+The TypeScript implementation supports either Node.js (>= 14.x) or a
 browser environment. When running on Node.js, it uses the Node.js built-in
 [crypto](https://nodejs.org/api/crypto.html) module. When running in a browser
 it uses the [Web Crypto API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Crypto_API),


### PR DESCRIPTION
The previous PR updated the `vscode-jsonrpc` library, which changed one of the interfaces implemented in this library. I don't know how I didn't catch the build errors before - I might have accidentally built and tested with a different version of `vscode-jsonrpc`.