### PR TITLE
Add .NET Framework 4.8 build target, remove .NET Core 2.1

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,3 +11,7 @@ trim_trailing_whitespace = true
 
 [*.cs]
 csharp_style_namespace_declarations = file_scoped:warning
+
+[*.{yml,yaml}]
+indent_style=space
+indent_size=2

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -23,9 +23,8 @@ jobs:
         uses: actions/setup-dotnet@v2
         with:
           dotnet-version: |
-            2.1.x
             3.1.x
-            5.0.x
+            6.0.x
 
       - name: Use global.json dotnet version
         uses: actions/setup-dotnet@v2
@@ -56,9 +55,14 @@ jobs:
 
       - name: Test TypeScript
         run: npm run test-ts
-      
-      - name: Test dotnet 2.1
-        run: npm run test-cs -- --release --serial --framework netcoreapp2.1
+
+      - name: Test .NET Framework
+        if: matrix.os == 'windows-latest'
+        run: npm run test-cs -- --release --serial --framework net48
+        continue-on-error: true
+
+      - name: Test dotnet 3.1
+        run: npm run test-cs -- --release --serial --framework netcoreapp3.1
         continue-on-error: true
 
       - name: Test dotnet 6.0

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -62,6 +62,7 @@ jobs:
 
       - name: Test TypeScript
         run: npm run test-ts
+        continue-on-error: true
 
       - name: Test .NET Framework
         if: matrix.os == 'windows-latest'

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -77,6 +77,13 @@ jobs:
         run: npm run test-cs -- --release --serial --framework net6.0
         continue-on-error: true
 
+      - name: Publish test results
+        uses: dorny/test-reporter@v1
+        with:
+          name: test (${{ runner.os }})
+          path: out/TestResults/*.trx
+          reporter: dotnet-trx
+
       - name: Start SSH debug session
         uses: mxschmitt/action-tmate@v3
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -4,6 +4,13 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch: # Enable manually starting a build
+    inputs:
+      debug_enabled:
+        type: boolean
+        description: 'Start an SSH debug session as the last step of the build'
+        required: false
+        default: false
 
 jobs:
   builds:
@@ -67,3 +74,11 @@ jobs:
 
       - name: Test dotnet 6.0
         run: npm run test-cs -- --release --serial --framework net6.0
+        continue-on-error: true
+
+      - name: Start SSH debug session
+        uses: mxschmitt/action-tmate@v3
+        if: matrix.os == 'macOS-latest'
+        #if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
+        with:
+            limit-access-to-actor: true

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -64,17 +64,17 @@ jobs:
         run: npm run test-ts
         continue-on-error: true
 
-      - name: Test .NET Framework
-        if: matrix.os == 'windows-latest'
-        run: npm run test-cs -- --release --serial --framework net48
-        continue-on-error: true
-
-      - name: Test dotnet 3.1
+      - name: Test .NET Core 3.1
         run: npm run test-cs -- --release --serial --framework netcoreapp3.1
         continue-on-error: true
 
-      - name: Test dotnet 6.0
+      - name: Test .NET 6
         run: npm run test-cs -- --release --serial --framework net6.0
+        continue-on-error: true
+
+      - name: Test .NET Framework 4.8
+        if: matrix.os == 'windows-latest'
+        run: npm run test-cs -- --release --serial --framework net48
         continue-on-error: true
 
       - name: Publish test results

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches:
       - main
-  workflow_dispatch: # Enable manually starting a build
+  workflow_dispatch: # Enable manually starting a build, with optional input parameters
     inputs:
       debug_enabled:
         type: boolean
@@ -79,7 +79,6 @@ jobs:
 
       - name: Start SSH debug session
         uses: mxschmitt/action-tmate@v3
-        if: matrix.os == 'macOS-latest'
-        #if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
         with:
             limit-access-to-actor: true

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -80,7 +80,7 @@ jobs:
       - name: Publish test results
         uses: dorny/test-reporter@v1
         with:
-          name: test (${{ runner.os }})
+          name: Test SSH on ${{ matrix.os }}
           path: out/TestResults/*.trx
           reporter: dotnet-trx
 

--- a/.pipelines/dev-tunnels-ssh-ci.yaml
+++ b/.pipelines/dev-tunnels-ssh-ci.yaml
@@ -110,13 +110,6 @@ jobs:
           customCommand: run test-ts -- --release --serial --coverage
 
       - task: Npm@1
-        displayName: Test (.NET Framework)
-        inputs:
-          command: custom
-          verbose: false
-          customCommand: run test-cs -- --release --serial --coverage --framework net48
-
-      - task: Npm@1
         displayName: Test (.NET Core 3.1)
         inputs:
           command: custom
@@ -129,6 +122,13 @@ jobs:
           command: custom
           verbose: false
           customCommand: run test-cs -- --release --serial --coverage --framework net6.0
+
+      - task: Npm@1
+        displayName: Test (.NET Framework 4.8)
+        inputs:
+          command: custom
+          verbose: false
+          customCommand: run test-cs -- --release --serial --coverage --framework net48
 
       - task: PublishSymbols@2
         displayName: Publish symbols

--- a/.pipelines/dev-tunnels-ssh-ci.yaml
+++ b/.pipelines/dev-tunnels-ssh-ci.yaml
@@ -39,22 +39,16 @@ jobs:
         fetchTags: false
         
       - task: UseDotNet@2
-        displayName: Install .NET Core 2.1 Runtime
-        inputs:
-          packageType: runtime
-          version: 2.1.x
-
-      - task: UseDotNet@2
         displayName: Install .NET Core 3.1 Runtime
         inputs:
           packageType: runtime
           version: 3.1.x
 
       - task: UseDotNet@2
-        displayName: Install .NET 5 Runtime
+        displayName: Install .NET 6 Runtime
         inputs:
           packageType: runtime
-          version: 5.0.x
+          version: 6.0.x
 
       - task: UseDotNet@2
         displayName: Use .NET SDK specified by global.json
@@ -116,11 +110,11 @@ jobs:
           customCommand: run test-ts -- --release --serial --coverage
 
       - task: Npm@1
-        displayName: Test (.NET Core 2.1)
+        displayName: Test (.NET Framework)
         inputs:
           command: custom
           verbose: false
-          customCommand: run test-cs -- --release --serial --coverage --framework netcoreapp2.1
+          customCommand: run test-cs -- --release --serial --coverage --framework net48
 
       - task: Npm@1
         displayName: Test (.NET Core 3.1)
@@ -227,22 +221,16 @@ jobs:
         fetchTags: false
 
       - task: UseDotNet@2
-        displayName: Install .NET Core 2.1 Runtime
-        inputs:
-          packageType: runtime
-          version: 2.1.x
-
-      - task: UseDotNet@2
         displayName: Install .NET Core 3.1 Runtime
         inputs:
           packageType: runtime
           version: 3.1.x
 
       - task: UseDotNet@2
-        displayName: Install .NET 5 Runtime
+        displayName: Install .NET 6 Runtime
         inputs:
           packageType: runtime
-          version: 5.0.x
+          version: 6.0.x
 
       - task: UseDotNet@2
         displayName: Use .NET SDK specified by global.json
@@ -280,13 +268,6 @@ jobs:
           command: custom
           verbose: false
           customCommand: run test-ts -- --release --serial
-
-      - task: Npm@1
-        displayName: Test (.NET Core 2.1)
-        inputs:
-          command: custom
-          verbose: false
-          customCommand: run test-cs -- --release --serial --framework netcoreapp2.1
 
       - task: Npm@1
         displayName: Test (.NET Core 3.1)

--- a/README.md
+++ b/README.md
@@ -53,10 +53,10 @@ on top of it:
 Future development may add support for some of these capabilities, likely in the
 form of additional optional packages.
 
-## C# (.NET Standard)
-.NET Standard 2.0 & 2.1 support means it can be used with .NET Framework 4.7+ on
-Windows or .NET Core 2.0+ on any platform. It's tested on Windows, Mac, & Ubuntu. For
-details about the .NET library, see [src/cs/Ssh/README.md](./src/cs/Ssh/README.md).
+## C# (.NET Framework, .NET Core, .NET 6)
+The C# library targets .NET Framework 4.8, .NET Standard 2.1 (.NET Core 3.1, .NET 5),
+and .NET 6. It's tested on Windows, Mac, & Ubuntu. For details about the .NET library,
+see [src/cs/Ssh/README.md](./src/cs/Ssh/README.md).
 
 ## TypeScript (Node.js or Browser)
 The TypeScript implementation supports either Node.js (>= 14.x) or a browser

--- a/bench/cs/Directory.Build.props
+++ b/bench/cs/Directory.Build.props
@@ -3,11 +3,12 @@
 	<Import Project="../../Directory.Build.props" />
 
 	<PropertyGroup>
-		<TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net6.0</TargetFrameworks>
+		<TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
+		<TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net48;$(TargetFrameworks)</TargetFrameworks>
+
 		<IsPackable>false</IsPackable>
 		<CodeAnalysisFile></CodeAnalysisFile>
 		<NoWarn>$(NoWarn);NU1701</NoWarn><!-- Package was restored using different target framework. -->
-		<NoWarn>$(NoWarn);NETSDK1138</NoWarn><!-- 'netcoreapp2.1' is out of support. It's only used for benchmarking netstandard2.0. -->
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)' == 'Release'">

--- a/bench/cs/Ssh.Benchmark/Benchmark.cs
+++ b/bench/cs/Ssh.Benchmark/Benchmark.cs
@@ -8,9 +8,11 @@ using System.Threading.Tasks;
 
 namespace Microsoft.DevTunnels.Ssh.Benchmark;
 
+#if NETSTANDARD2_0 || NET4
+using ValueTask = System.Threading.Tasks.Task;
 public abstract class Benchmark
-#if !NETSTANDARD2_0
-		: IAsyncDisposable
+#else
+public abstract class Benchmark : IAsyncDisposable
 #endif
 {
 	public static async Task Main(string[] args)
@@ -52,8 +54,11 @@ public abstract class Benchmark
 
 		ServerPort = GetAvailableTcpPort();
 
-		foreach (var (benchmarkName, benchmarkFunc) in benchmarks)
+		foreach (var benchmarkPair in benchmarks)
 		{
+			var benchmarkName = benchmarkPair.Key;
+			var benchmarkFunc = benchmarkPair.Value;
+
 			if (nameList != null && !nameList.Contains(benchmarkName))
 			{
 				continue;
@@ -128,8 +133,11 @@ public abstract class Benchmark
 	{
 		Console.WriteLine();
 
-		foreach (var (measurement, measurements) in Measurements)
+		foreach (var measurementPair in Measurements)
 		{
+			var measurement = measurementPair.Key;
+			var measurements = measurementPair.Value;
+
 			if (!HigherIsBetter.TryGetValue(measurement, out var higherIsBetter))
 			{
 				higherIsBetter = true;

--- a/bench/cs/Ssh.Benchmark/SessionSetupBenchmark.cs
+++ b/bench/cs/Ssh.Benchmark/SessionSetupBenchmark.cs
@@ -14,6 +14,10 @@ using Microsoft.DevTunnels.Ssh.Tcp;
 
 namespace Microsoft.DevTunnels.Ssh.Benchmark;
 
+#if NETSTANDARD2_0 || NET4
+using ValueTask = System.Threading.Tasks.Task;
+#endif
+
 class SessionSetupBenchmark : Benchmark
 {
 	private const string ConnectTimeMeasurement = "Connect time (ms)";

--- a/bench/cs/Ssh.Benchmark/SlowStream.cs
+++ b/bench/cs/Ssh.Benchmark/SlowStream.cs
@@ -85,18 +85,19 @@ class SlowStream : Stream
 
 		Task.Run(async () =>
 		{
-				// Spinning like this is horribly inefficient, but for benchmarking purposes it enables
-				// a much more precise latency simulation compared to something like Task.Delay(ms).
-				while (stopwatch.ElapsedMilliseconds < AddedLatency.TotalMilliseconds)
+			// Spinning like this is horribly inefficient, but for benchmarking purposes it enables
+			// a much more precise latency simulation compared to something like Task.Delay(ms).
+			while (stopwatch.ElapsedMilliseconds < AddedLatency.TotalMilliseconds)
 			{
 				await Task.Yield();
 			}
 
-				// Lock while dequeuing+writing to ensure blocks are written to the base stream in order.
-				lock (this.writeQueue)
+			// Lock while dequeuing+writing to ensure blocks are written to the base stream in order.
+			lock (this.writeQueue)
 			{
-				while (count-- > 0 && this.writeQueue.TryDequeue(out var buffer))
+				while (count-- > 0 && this.writeQueue.Count > 0)
 				{
+					var buffer = this.writeQueue.Dequeue();
 					BaseStream.Write(buffer, 0, buffer.Length);
 				}
 			}

--- a/bench/cs/Ssh.Benchmark/ThroughputBenchmark.cs
+++ b/bench/cs/Ssh.Benchmark/ThroughputBenchmark.cs
@@ -11,6 +11,10 @@ using Microsoft.DevTunnels.Ssh.Tcp;
 
 namespace Microsoft.DevTunnels.Ssh.Benchmark;
 
+#if NETSTANDARD2_0 || NET4
+using ValueTask = System.Threading.Tasks.Task;
+#endif
+
 class ThroughputBenchmark : Benchmark
 {
 	private const string MessageCountMeasurement = "Throughput (msgs/s)";
@@ -84,7 +88,8 @@ class ThroughputBenchmark : Benchmark
 
 			var channel = await clientSession.OpenChannelAsync();
 
-			var cancellationSource = new CancellationTokenSource(2 * this.duration);
+			var cancellationSource = new CancellationTokenSource(
+				TimeSpan.FromSeconds(this.duration.TotalSeconds * 2));
 
 			int messageCount = 0;
 			stopwatch.Restart();

--- a/build.js
+++ b/build.js
@@ -215,8 +215,8 @@ yargs.command('test-cs', 'Run C# tests', async (yargs) => {
 		fs.writeFileSync(testConfigFile, JSON.stringify(testConfig, null, '\t'));
 	}
 
-	// A date-time suffix will automatically be appended to the TRX filename.
-	const trxBaseFileName = path.join(testResultsDir, 'SSH-CS.trx');
+	const targetAppFramework = getTargetAppFramework(yargs.argv.framework);
+	const trxBaseFileName = path.join(testResultsDir, `SSH-CS-${targetAppFramework}.trx`);
 
 	const verbosity = yargs.argv.verbosity || 'normal';
 	let command =
@@ -227,7 +227,7 @@ yargs.command('test-cs', 'Run C# tests', async (yargs) => {
 		` -l:"trx;LogFileName=${trxBaseFileName}"`;
 
 	if (yargs.argv.framework) {
-		command += ` --framework ${getTargetAppFramework(yargs.argv.framework)}`;
+		command += ` --framework ${targetAppFramework}`;
 	}
 	if (yargs.argv.filter) {
 		command += ` --filter ${yargs.argv.filter}`;

--- a/build.js
+++ b/build.js
@@ -36,7 +36,7 @@ yargs.option('release', {
 });
 yargs.option('framework', {
 	desc: 'Specify .net application framework',
-	choices: ['netcoreapp2.1', 'netcoreapp3.1', 'net6.0', 'netstandard2.0', 'netstandard2.1'],
+	choices: ['net48', 'netcoreapp2.1', 'netcoreapp3.1', 'net6.0', 'netstandard2.1'],
 	group: buildGroup,
 });
 yargs.option('msbuild', {
@@ -360,12 +360,8 @@ async function linkLib(packageName, dirName) {
 function getTargetAppFramework(framework) {
 	if (!framework || framework == 'netstandard2.1' || framework == 'netcoreapp3.1') {
 		return 'netcoreapp3.1';
-	} else if (framework == 'netstandard2.0' || framework == 'netcoreapp2.1') {
-		return 'netcoreapp2.1';
-	} else if (framework == 'net5.0') {
-		return 'net5.0';
-	} else if (framework == 'net6.0') {
-		return 'net6.0';
+	} else if (framework == 'net6.0' || framework == 'net48') {
+		return framework;
 	} else {
 		throw new Error('Invalid target framework: ' + framework);
 	}

--- a/build/config.props
+++ b/build/config.props
@@ -46,13 +46,19 @@
 	<PropertyGroup>
 		<DotNetStandard20 Condition="'$(TargetFramework)'=='netstandard2.0' OR '$(TargetFramework)'=='netcoreapp2.1'">true</DotNetStandard20>
 		<DotNetStandard21 Condition="'$(TargetFramework)'=='netstandard2.1' OR '$(TargetFramework)'=='netcoreapp3.1'">true</DotNetStandard21>
+		<DotNet4 Condition="$(TargetFramework.StartsWith('net4'))">true</DotNet4>
 		<DotNet5 Condition="'$(TargetFramework)'=='net5.0'">true</DotNet5>
 		<DotNet6 Condition="'$(TargetFramework)'=='net6.0'">true</DotNet6>
 
 		<DefineConstants Condition="'$(DotNetStandard20)'=='true'">$(DefineConstants);NETSTANDARD2_0</DefineConstants>
 		<DefineConstants Condition="'$(DotNetStandard21)'=='true'">$(DefineConstants);NETSTANDARD2_1</DefineConstants>
+		<DefineConstants Condition="'$(DotNet4)'=='true'">$(DefineConstants);NET4</DefineConstants>
 		<DefineConstants Condition="'$(DotNet5)'=='true'">$(DefineConstants);NET5_0</DefineConstants>
 		<DefineConstants Condition="'$(DotNet6)'=='true'">$(DefineConstants);NET6_0</DefineConstants>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(DotNet4)'=='true'">
+		<DefineConstants>$(DefineConstants);SSH_ENABLE_ECDH</DefineConstants>
+		<DefineConstants>$(DefineConstants);SSH_ENABLE_PBKDF2</DefineConstants>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(DotNetStandard21)'=='true' OR '$(DotNet5)'=='true' OR '$(DotNet6)' == 'true'">
 		<DefineConstants>$(DefineConstants);SSH_ENABLE_SPAN</DefineConstants>

--- a/src/cs/Directory.Build.props
+++ b/src/cs/Directory.Build.props
@@ -3,9 +3,13 @@
 	<Import Project="../../Directory.Build.props" />
 
 	<PropertyGroup>
-		<TargetFrameworks>netstandard2.0;netstandard2.1;net6.0</TargetFrameworks>
+		<TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
+		<TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
+		<TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net48;$(TargetFrameworks)</TargetFrameworks>
+
 		<IsPackable>true</IsPackable>
 		<NoWarn>$(NoWarn);CS1591</NoWarn><!-- Missing XML comment for publicly visible type or member -->
+		<NoWarn>$(NoWarn);CA2237</NoWarn><!-- Add [Serializable] to exceptions (.NET Framework) -->
 	</PropertyGroup>
 
 	<PropertyGroup Condition=" '$(EnableSigning)' == 'true' ">

--- a/src/cs/Ssh.Keys/KeyData.cs
+++ b/src/cs/Ssh.Keys/KeyData.cs
@@ -181,7 +181,7 @@ public class KeyData
 
 	private static KeyValuePair<string, string> ParsePemHeader(string header)
 	{
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0 || NET4
 		header = header.Replace("\r", string.Empty).Replace("\\\n", string.Empty).TrimEnd('\n');
 #else
 		header = header.Replace("\r", string.Empty, StringComparison.Ordinal)

--- a/src/cs/Ssh.Keys/KeyPair.cs
+++ b/src/cs/Ssh.Keys/KeyPair.cs
@@ -366,7 +366,7 @@ public static class KeyPair
 	{
 		// Different formats may use different casing and hyphens. Normalize before comparing.
 		algorithm = algorithm.ToUpperInvariant();
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0 || NET4
 		algorithm = algorithm.Replace("-", string.Empty);
 #else
 		algorithm = algorithm.Replace("-", string.Empty, StringComparison.Ordinal);

--- a/src/cs/Ssh.Keys/Pkcs8KeyFormatter.cs
+++ b/src/cs/Ssh.Keys/Pkcs8KeyFormatter.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
 using Microsoft.DevTunnels.Ssh.Algorithms;
@@ -505,7 +506,15 @@ public class Pkcs8KeyFormatter : IKeyFormatter
 			(privateKeyData.Count % encryption.BlockLength);
 		var paddedData = new Buffer(privateKeyData.Count + paddingLength);
 		privateKeyData.CopyTo(paddedData);
+
+#if NET4
+		for (int i = 0; i < paddingLength; i++)
+		{
+			paddedData.Array[privateKeyData.Count + i] = (byte)paddingLength;
+		}
+#else
 		Array.Fill(paddedData.Array, (byte)paddingLength, privateKeyData.Count, paddingLength);
+#endif
 		privateKeyData = paddedData;
 
 		using var cipher = encryption.CreateCipher(isEncryption: true, key, iv);

--- a/src/cs/Ssh.Tcp/Services/ChannelForwarder.cs
+++ b/src/cs/Ssh.Tcp/Services/ChannelForwarder.cs
@@ -263,23 +263,39 @@ internal class ChannelForwarder : IDisposable
 			return false;
 		}
 
+		// Do not use the (dispose) cancellation token when writing to the channel, because
+		// an interrupted write can cause the whole SSH session to disconnect.
 		if (count > 0)
 		{
-			await Channel.SendAsync(buffer.Slice(0, count), cancellation).ConfigureAwait(false);
+			await Channel.SendAsync(buffer.Slice(0, count), CancellationToken.None)
+				.ConfigureAwait(false);
 			return true;
 		}
 		else if (ex == null)
 		{
 			string message = "Channel forwarder reached end of stream.";
 			this.trace.TraceEvent(TraceEventType.Verbose, SshTraceEventIds.ChannelClosed, message);
-			await Channel.SendAsync(Buffer.Empty, cancellation).ConfigureAwait(false);
-			await Channel.CloseAsync(cancellation).ConfigureAwait(false);
+			try
+			{
+				await Channel.SendAsync(Buffer.Empty, CancellationToken.None).ConfigureAwait(false);
+				await Channel.CloseAsync(CancellationToken.None).ConfigureAwait(false);
+			}
+			catch (OperationCanceledException)
+			{
+			}
 		}
 		else
 		{
 			string message = $"Channel forwarder stream read error: {ex.Message}";
 			this.trace.TraceEvent(TraceEventType.Verbose, SshTraceEventIds.ChannelClosed, message);
-			await Channel.CloseAsync("SIGABRT", ex.Message, cancellation).ConfigureAwait(false);
+			try
+			{
+				await Channel.CloseAsync("SIGABRT", ex.Message, CancellationToken.None)
+					.ConfigureAwait(false);
+			}
+			catch (OperationCanceledException)
+			{
+			}
 		}
 
 		return false;

--- a/src/cs/Ssh.Tcp/Services/ChannelForwarder.cs
+++ b/src/cs/Ssh.Tcp/Services/ChannelForwarder.cs
@@ -241,7 +241,7 @@ internal class ChannelForwarder : IDisposable
 		Exception? ex = null;
 		try
 		{
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0 || NET4
 			count = await this.stream.ReadAsync(
 				buffer.Array, buffer.Offset, buffer.Count, cancellation).ConfigureAwait(false);
 #else

--- a/src/cs/Ssh.Tcp/Services/LocalPortForwarder.cs
+++ b/src/cs/Ssh.Tcp/Services/LocalPortForwarder.cs
@@ -271,14 +271,15 @@ public class LocalPortForwarder : SshService
 		{
 			try
 			{
+				this.disposeCancellationSource.Cancel();
+			}
+			catch (ObjectDisposedException) { }
+
+			try
+			{
 				// Note stopping the listener does NOT disconnect any already-accepted sockets.
 				this.listener?.Stop();
 				this.listener2?.Stop();
-			}
-			catch (ObjectDisposedException) { }
-			try
-			{
-				this.disposeCancellationSource.Cancel();
 			}
 			catch (ObjectDisposedException) { }
 

--- a/src/cs/Ssh/Algorithms/SshAlgorithm.cs
+++ b/src/cs/Ssh/Algorithms/SshAlgorithm.cs
@@ -63,6 +63,10 @@ public abstract class SshAlgorithm
 
 	private static Assembly? InitializeCngAssembly()
 	{
+#if NET4
+		// Crypto implementation types are in System.Core on .NET Framework 4.x.
+		return typeof(ECDiffieHellmanCng).Assembly;
+#else
 		var ns = typeof(SymmetricAlgorithm).Namespace;
 		try
 		{
@@ -73,6 +77,7 @@ public abstract class SshAlgorithm
 			// The System.Security.Cryptography.Cng asembly was not found.
 			return null;
 		}
+#endif
 	}
 
 #if NET6_0_OR_GREATER

--- a/src/cs/Ssh/IO/SshProtocol.cs
+++ b/src/cs/Ssh/IO/SshProtocol.cs
@@ -725,7 +725,7 @@ internal class SshProtocol : IDisposable
 		}
 		finally
 		{
-			this.sessionSemaphore.Release();
+			this.sessionSemaphore.TryRelease();
 		}
 
 		await ConsiderReExchangeAsync(initial: false, cancellation).ConfigureAwait(false);

--- a/src/cs/Ssh/MultiChannelStream.cs
+++ b/src/cs/Ssh/MultiChannelStream.cs
@@ -326,7 +326,7 @@ public class MultiChannelStream : IDisposable
 		await this.session.CloseAsync(SshDisconnectReason.None, this.session.GetType().Name + " disposed").ConfigureAwait(false);
 		this.session.Dispose();
 
-#if !NETSTANDARD2_0
+#if !NETSTANDARD2_0 && !NET4
 		await this.transportStream.DisposeAsync().ConfigureAwait(false);
 #else
 		this.transportStream.Dispose();

--- a/src/cs/Ssh/MultiChannelStream.cs
+++ b/src/cs/Ssh/MultiChannelStream.cs
@@ -232,7 +232,7 @@ public class MultiChannelStream : IDisposable
 		string? channelType,
 		CancellationToken cancellation = default)
 	{
-		await this.session.ConnectAsync(this.transportStream, cancellation).ConfigureAwait(false);
+		await ConnectAsync(cancellation).ConfigureAwait(false);
 		var channel = await this.session.AcceptChannelAsync(channelType, cancellation)
 			.ConfigureAwait(false);
 		return channel;
@@ -333,9 +333,7 @@ public class MultiChannelStream : IDisposable
 	/// </summary>
 	public async Task CloseAsync()
 	{
-		await this.session.CloseAsync(
-			SshDisconnectReason.None,
-			$"{nameof(MultiChannelStream)} disposed.").ConfigureAwait(false);
+		await this.session.CloseAsync(SshDisconnectReason.None, this.session.GetType().Name + " disposed").ConfigureAwait(false);
 		this.session.Dispose();
 
 #if !NETSTANDARD2_0 && !NET4

--- a/src/cs/Ssh/README.md
+++ b/src/cs/Ssh/README.md
@@ -11,30 +11,21 @@ A Secure Shell (SSH2) client and server protocol implementation for .NET.
 
 ## Requirements
 This library targets the following .NET versions:
- - .NET Standard 2.0
- - .NET Standard 2.1
+ - .NET Framework 4.8
+ - .NET Standard 2.1 (.NET Core 3.1, .NET 5)
  - .NET 6
 
-The .NET Standard 2.0 support means it can be used with .NET Framework 4.7+ on
-Windows or .NET Core 2.0+ on any platform.
+The .NET Framework target runs only on Windows (of course); the other targets support
+Windows, Mac, and Linux.
 
-Some minor functionality is only available with .NET Standard 2.1 or later:
- - **ECDH** - Elliptic-curve Diffie-Hellman key-exchange (faster than normal
-   DH) is only available with .NET Standard 2.1 or later.
+Some minor functionality is not available in the .NET Framework target:
  - **AES-GCM** - This cipher algorithm is available (and preferred) when using
-   .NET Standard 2.1 or later. If using .NET Standard 2.0, or if the other
+   .NET Standard 2.1 or later. If using .NET Framework, or if the other
    side does not support it, then other cipher and MAC algorithms (AES-CTR,
    SHA2-ETM) are used instead.
  - **Use of `Span<T>`** - There is no functional difference, but this reduces
    the amount of memory allocations and copies, allowing for a slight
    performance improvement with .NET Standard 2.1 or later.
- - **Password-protected PKCS#8 keys** - This functionality is only available
-   with .NET Standard 2.1 or later. It's not possible to import/export
-   password-protected PKCS#8 key files with the .NET Standard 2.0 target
-   because the required key-derivation function is not available. Use a
-   different key format (such as OpenSSH) instead if support for key file
-   encryption is required. (Unencrypted PKCS#8 keys are still supported
-   with .NET Standard 2.0.)
 
 ### OS Requirements
 Crypto algorithms work across all .NET Core platforms: Windows, Mac, and Linux.

--- a/src/cs/Ssh/SecureStream.cs
+++ b/src/cs/Ssh/SecureStream.cs
@@ -208,7 +208,7 @@ public class SecureStream : Stream
 			SshDisconnectReason.None, this.session.GetType().Name + " disposed").ConfigureAwait(false);
 		this.session.Dispose();
 
-#if !NETSTANDARD2_0
+#if !NETSTANDARD2_0 && !NET4
 		await this.transportStream.DisposeAsync().ConfigureAwait(false);
 #else
 		this.transportStream.Dispose();

--- a/src/cs/Ssh/SshChannel.cs
+++ b/src/cs/Ssh/SshChannel.cs
@@ -843,7 +843,8 @@ public class SshChannel : IDisposable
 		this.taskChain.Dispose();
 	}
 
-	private void CancelPendingRequests() {
+	private void CancelPendingRequests()
+	{
 		foreach (var completion in this.requestCompletionSources)
 		{
 			completion.TrySetResult(false);

--- a/src/cs/Ssh/SshSession.cs
+++ b/src/cs/Ssh/SshSession.cs
@@ -1109,7 +1109,7 @@ public class SshSession : IDisposable
 		}
 		finally
 		{
-			sessionRequestSemaphore.Release();
+			sessionRequestSemaphore.TryRelease();
 		}
 
 		return await requestHandler.CompletionSource.Task.ConfigureAwait(false);

--- a/test/cs/Directory.Build.props
+++ b/test/cs/Directory.Build.props
@@ -3,7 +3,8 @@
 	<Import Project="../../Directory.Build.props" />
 
 	<PropertyGroup>
-		<TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net6.0</TargetFrameworks>
+		<TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
+		<TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net48;$(TargetFrameworks)</TargetFrameworks>
 
 		<IsPackable>false</IsPackable>
 		<TestResultsDirectory Condition=" '$(TestResultsDirectory)' == '' ">$(BaseOutputPath)TestResults</TestResultsDirectory>
@@ -11,7 +12,6 @@
 		<CodeAnalysisFile></CodeAnalysisFile>
 		<NoWarn>$(NoWarn);VSTHRD200</NoWarn><!-- Test methods don't need to end with Async suffix. -->
 		<NoWarn>$(NoWarn);NU1701</NoWarn><!-- Package was restored using different target framework. -->
-		<NoWarn>$(NoWarn);NETSDK1138</NoWarn><!-- 'netcoreapp2.1' is out of support. It's only used for testing netstandard2.0. -->
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/test/cs/Ssh.Test/InteropTests.cs
+++ b/test/cs/Ssh.Test/InteropTests.cs
@@ -237,6 +237,7 @@ public class InteropTests
 			{
 				RedirectStandardOutput = true,
 				RedirectStandardError = true,
+				UseShellExecute = false,
 			};
 
 			DataReceivedEventHandler dataReceivedHandler = (sender, e) =>
@@ -384,6 +385,7 @@ public class InteropTests
 			{
 				RedirectStandardOutput = true,
 				RedirectStandardError = true,
+				UseShellExecute = false,
 			};
 
 			DataReceivedEventHandler dataReceivedHandler = (sender, e) =>
@@ -412,7 +414,7 @@ public class InteropTests
 				catch (Exception ex) when (ex is SocketException ||
 					(ex is SshConnectionException ce &&
 					ce.DisconnectReason == SshDisconnectReason.ConnectionLost) ||
-					ex.Message.Contains("connection", StringComparison.OrdinalIgnoreCase))
+					ex.Message.IndexOf("connection", StringComparison.OrdinalIgnoreCase) >= 0)
 				{
 					if (i >= 9) throw;
 
@@ -534,6 +536,7 @@ public class InteropTests
 			{
 				RedirectStandardOutput = true,
 				RedirectStandardError = true,
+				UseShellExecute = false,
 			};
 
 			DataReceivedEventHandler dataReceivedHandler = (sender, e) =>
@@ -597,6 +600,7 @@ public class InteropTests
 			{
 				RedirectStandardOutput = true,
 				RedirectStandardError = true,
+				UseShellExecute = false,
 			};
 
 			bool foundTestCommand = false;
@@ -816,13 +820,15 @@ public class InteropTests
 		if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
 		{
 			var pathEnv = Environment.GetEnvironmentVariable("PATH") ?? string.Empty;
-			foreach (string dir in pathEnv.Split(
-				Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries))
+			foreach (string dir in pathEnv.Split(Path.PathSeparator))
 			{
-				var dirAndName = Path.Combine(dir, name);
-				if (File.Exists(dirAndName))
+				if (!string.IsNullOrEmpty(dir))
 				{
-					return dirAndName;
+					var dirAndName = Path.Combine(dir, name);
+					if (File.Exists(dirAndName))
+					{
+						return dirAndName;
+					}
 				}
 			}
 
@@ -865,7 +871,12 @@ public class InteropTests
 
 	private static string GetRepoRoot()
 	{
+#if NET4
+		var rootDir = Path.GetDirectoryName(
+			new Uri(typeof(InteropTests).Assembly.CodeBase).AbsolutePath);
+#else
 		var rootDir = Path.GetDirectoryName(typeof(InteropTests).Assembly.Location);
+#endif
 		while (!File.Exists(Path.Combine(rootDir, "SSH.sln")))
 		{
 			rootDir = Path.GetDirectoryName(rootDir);

--- a/test/cs/Ssh.Test/InteropTests.cs
+++ b/test/cs/Ssh.Test/InteropTests.cs
@@ -102,6 +102,12 @@ public class InteropTests
 		config.PublicKeyAlgorithms.Add(SshAlgorithms.PublicKey.ECDsaSha2Nistp521);
 
 		var kexAlgorithm = config.KeyExchangeAlgorithms.Single((a) => a?.Name == kexAlgorithmName);
+		if (!kexAlgorithm.IsAvailable)
+		{
+			throw new PlatformNotSupportedException(
+				$"Algorithm '{kexAlgorithmName}' is not available.");
+		}
+
 		config.KeyExchangeAlgorithms.Clear();
 		config.KeyExchangeAlgorithms.Add(kexAlgorithm);
 
@@ -123,7 +129,8 @@ public class InteropTests
 
 #if SSH_ENABLE_AESGCM
 		// Enable AES-GCM for a subset of test cases. Not all, to keep coverage of HMAC algs.
-		if (publicKeyAlgorithmName.StartsWith("ecdsa-"))
+		if (publicKeyAlgorithmName.StartsWith("ecdsa-") &&
+			SshAlgorithms.Encryption.Aes256Gcm.IsAvailable)
 		{
 			config.EncryptionAlgorithms.Clear();
 			config.EncryptionAlgorithms.Add(SshAlgorithms.Encryption.Aes256Gcm);
@@ -683,6 +690,12 @@ public class InteropTests
 		config.PublicKeyAlgorithms.Add(SshAlgorithms.PublicKey.ECDsaSha2Nistp521);
 
 		var kexAlgorithm = config.KeyExchangeAlgorithms.Single((a) => a?.Name == kexAlgorithmName);
+		if (!kexAlgorithm.IsAvailable)
+		{
+			throw new PlatformNotSupportedException(
+				$"Algorithm '{kexAlgorithmName}' is not available.");
+		}
+
 		config.KeyExchangeAlgorithms.Clear();
 		config.KeyExchangeAlgorithms.Add(kexAlgorithm);
 
@@ -702,7 +715,8 @@ public class InteropTests
 
 #if SSH_ENABLE_AESGCM
 		// Enable AES-GCM for a subset of test cases. Not all, to keep coverage of HMAC algs.
-		if (publicKeyAlgorithmName.StartsWith("ecdsa-"))
+		if (publicKeyAlgorithmName.StartsWith("ecdsa-") &&
+			SshAlgorithms.Encryption.Aes256Gcm.IsAvailable)
 		{
 			config.EncryptionAlgorithms.Clear();
 			config.EncryptionAlgorithms.Add(SshAlgorithms.Encryption.Aes256Gcm);

--- a/test/cs/Ssh.Test/InteropTests.cs
+++ b/test/cs/Ssh.Test/InteropTests.cs
@@ -328,7 +328,7 @@ public class InteropTests
 	/// and validates that the client can connect, encrypt, and authenticate the session.
 	/// </summary>
 	/// <param name="reconnect">True to test interop of the session reconnect protocol.</param>
-	[Theory]
+	[SkippableTheory(typeof(PlatformNotSupportedException))]
 	[InlineData("diffie-hellman-group14-sha256", ECDsa.ECDsaSha2Nistp521, "hmac-sha2-512", false)]
 	[InlineData("diffie-hellman-group14-sha256", Rsa.RsaWithSha512, "hmac-sha2-512", true)]
 	[InlineData("diffie-hellman-group16-sha512", Rsa.RsaWithSha512, "hmac-sha2-512-etm@openssh.com", false)]

--- a/test/cs/Ssh.Test/MetricsTests.cs
+++ b/test/cs/Ssh.Test/MetricsTests.cs
@@ -123,9 +123,9 @@ public class MetricsTests : IDisposable
 
 		void ValidateLatency(SessionMetrics metrics)
 		{
-			Assert.NotEqual(0, metrics.LatencyMinMs);
-			Assert.NotEqual(0, metrics.LatencyAverageMs);
 			Assert.NotEqual(0, metrics.LatencyMaxMs);
+			Assert.NotEqual(0, metrics.LatencyAverageMs);
+			Assert.NotEqual(0, metrics.LatencyMinMs);
 			Assert.NotEqual(0, metrics.LatencyCurrentMs);
 			Assert.True(metrics.LatencyMinMs <= metrics.LatencyAverageMs);
 			Assert.True(metrics.LatencyAverageMs <= metrics.LatencyMaxMs);

--- a/test/cs/Ssh.Test/MultiChannelStreamTests.cs
+++ b/test/cs/Ssh.Test/MultiChannelStreamTests.cs
@@ -162,7 +162,7 @@ public class MultiChannelStreamTests
 		var serverChannel = await serverChannelTask.WithTimeout(Timeout);
 		Assert.NotNull(serverChannel);
 
-#if !NETSTANDARD2_0
+#if !NETSTANDARD2_0 && !NET4
 		await clientChannel.DisposeAsync();
 		await serverStream.DisposeAsync();
 

--- a/test/cs/Ssh.Test/PortForwardingTests.cs
+++ b/test/cs/Ssh.Test/PortForwardingTests.cs
@@ -836,8 +836,9 @@ public class PortForwardingTests : IDisposable
 			var readBuffer = new byte[1];
 			var ioex = await Assert.ThrowsAsync<IOException>(async () =>
 			{
-				await (remoteEnd ? localStream : remoteStream).ReadAsync(
+				var result = await (remoteEnd ? localStream : remoteStream).ReadAsync(
 					readBuffer, 0, readBuffer.Length).WithTimeout(Timeout);
+				throw new InvalidOperationException($"Read returned {result} bytes.");
 			});
 			Assert.IsType<SocketException>(ioex.InnerException);
 

--- a/test/cs/Ssh.Test/PortForwardingTests.cs
+++ b/test/cs/Ssh.Test/PortForwardingTests.cs
@@ -214,7 +214,7 @@ public class PortForwardingTests : IDisposable
 	[InlineData("0.0.0.0", "127.0.0.1", "localhost", "127.0.0.1")]
 	[InlineData("127.0.0.1", "127.0.0.1", "127.0.0.1", "127.0.0.1")]
 	[InlineData("127.0.0.1", "127.0.0.1", "localhost", "127.0.0.1")]
-#if !NETCOREAPP2_1
+#if !NETCOREAPP2_1 && !NET4
 	[InlineData("0.0.0.0", "::1", "::1", "::1")]
 	[InlineData("127.0.0.1", "::1", "localhost", "::1")]
 	[InlineData("::", "::1", "localhost", "::1")]
@@ -250,8 +250,8 @@ public class PortForwardingTests : IDisposable
 			var localStream = localClient.GetStream();
 
 			var writeBuffer = new byte[] { 1, 2, 3 };
-			await remoteStream.WriteAsync(writeBuffer);
-			await localStream.WriteAsync(writeBuffer);
+			await remoteStream.WriteAsync(writeBuffer, 0, writeBuffer.Length);
+			await localStream.WriteAsync(writeBuffer, 0, writeBuffer.Length);
 
 			var readBuffer = new byte[10];
 			int count = await localStream.ReadAsync(readBuffer, 0, readBuffer.Length)
@@ -583,7 +583,7 @@ public class PortForwardingTests : IDisposable
 	[InlineData("0.0.0.0", "127.0.0.1", "localhost", "127.0.0.1")]
 	[InlineData("127.0.0.1", "127.0.0.1", "127.0.0.1", "127.0.0.1")]
 	[InlineData("127.0.0.1", "127.0.0.1", "localhost", "127.0.0.1")]
-#if !NETCOREAPP2_1
+#if !NETCOREAPP2_1 && !NET4
 	[InlineData("127.0.0.1", "::1", "localhost", "::1")]
 	[InlineData("::1", "::1", "::1", "::1")]
 	[InlineData("::1", "::1", "localhost", "::1")]
@@ -626,8 +626,8 @@ public class PortForwardingTests : IDisposable
 			Assert.NotNull(forwardingChannel);
 
 			var writeBuffer = new byte[] { 1, 2, 3 };
-			await remoteStream.WriteAsync(writeBuffer);
-			await localStream.WriteAsync(writeBuffer);
+			await remoteStream.WriteAsync(writeBuffer, 0, writeBuffer.Length);
+			await localStream.WriteAsync(writeBuffer, 0, writeBuffer.Length);
 
 			var readBuffer = new byte[10];
 			int count = await localStream.ReadAsync(readBuffer, 0, readBuffer.Length)
@@ -869,8 +869,8 @@ public class PortForwardingTests : IDisposable
 			var remoteStream = remoteClient.GetStream();
 
 			var writeBuffer = new byte[] { 1, 2, 3 };
-			await remoteStream.WriteAsync(writeBuffer);
-			await localStream.WriteAsync(writeBuffer);
+			await remoteStream.WriteAsync(writeBuffer, 0, writeBuffer.Length);
+			await localStream.WriteAsync(writeBuffer, 0, writeBuffer.Length);
 
 			var readBuffer = new byte[10];
 			int count = await localStream.ReadAsync(readBuffer, 0, readBuffer.Length)
@@ -938,8 +938,8 @@ public class PortForwardingTests : IDisposable
 		var localStream = await openCompletion.Task.WithTimeout(Timeout);
 
 		var writeBuffer = new byte[] { 1, 2, 3 };
-		await remoteStream.WriteAsync(writeBuffer);
-		await localStream.WriteAsync(writeBuffer);
+		await remoteStream.WriteAsync(writeBuffer, 0, writeBuffer.Length);
+		await localStream.WriteAsync(writeBuffer, 0, writeBuffer.Length);
 
 		var readBuffer = new byte[10];
 		int count = await localStream.ReadAsync(readBuffer, 0, readBuffer.Length)

--- a/test/cs/Ssh.Test/ReconnectTests.cs
+++ b/test/cs/Ssh.Test/ReconnectTests.cs
@@ -13,6 +13,7 @@ namespace Microsoft.DevTunnels.Ssh.Test;
 public class ReconnectTests : IDisposable
 {
 	private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(10);
+	private static readonly TimeSpan LongTimeout = TimeSpan.FromSeconds(100);
 	private static readonly SessionRequestMessage TestRequestMessage =
 		new SessionRequestMessage { RequestType = "test", WantReply = true };
 
@@ -33,7 +34,7 @@ public class ReconnectTests : IDisposable
 	public ReconnectTests()
 	{
 		InitializeSessionPair();
-		this.cancellation = new CancellationTokenSource(Timeout * 20).Token;
+		this.cancellation = new CancellationTokenSource(LongTimeout).Token;
 	}
 
 	public void Dispose()
@@ -460,8 +461,6 @@ public class ReconnectTests : IDisposable
 		SetKeyRotationThreshold(this.sessionPair.ServerSession, testKeyRotationThreshold);
 		SetKeyRotationThreshold(this.sessionPair.ClientSession, testKeyRotationThreshold);
 
-		var longTimeoutCancellation = new CancellationTokenSource(Timeout * 10).Token;
-
 		await this.sessionPair.ConnectAsync().WithTimeout(Timeout);
 		await WaitUntilReconnectEnabled().WithTimeout(Timeout);
 		var (serverChannel, clientChannel) = await InitializeChannelPairAsync(
@@ -481,8 +480,8 @@ public class ReconnectTests : IDisposable
 		const int messageCount = testKeyRotationThreshold / largeMessageSize + 5;
 		for (int i = 0; i < messageCount; i++)
 		{
-			await clientChannel.SendAsync(largeData, longTimeoutCancellation)
-				.WithTimeout(2 * Timeout);
+			await clientChannel.SendAsync(largeData, cancellation)
+				.WithTimeout(TimeSpan.FromSeconds(Timeout.TotalSeconds * 2));
 		}
 	}
 

--- a/test/cs/Ssh.Test/SecureStreamTests.cs
+++ b/test/cs/Ssh.Test/SecureStreamTests.cs
@@ -65,8 +65,8 @@ public class SecureStreamTests
 			Assert.False(authenticateSuccess);
 		}
 
-		Assert.Equal(authenticateSuccess, serverConnectTask.IsCompletedSuccessfully);
-		Assert.Equal(authenticateSuccess, clientConnectTask.IsCompletedSuccessfully);
+		Assert.Equal(authenticateSuccess, !serverConnectTask.IsFaulted);
+		Assert.Equal(authenticateSuccess, !clientConnectTask.IsFaulted);
 		if (!authenticateSuccess)
 		{
 			var serverEx = await Assert.ThrowsAsync<SshConnectionException>(() => serverConnectTask);
@@ -111,8 +111,8 @@ public class SecureStreamTests
 			Assert.False(authenticateSuccess);
 		}
 
-		Assert.Equal(authenticateSuccess, serverConnectTask.IsCompletedSuccessfully);
-		Assert.Equal(authenticateSuccess, clientConnectTask.IsCompletedSuccessfully);
+		Assert.Equal(authenticateSuccess, !serverConnectTask.IsFaulted);
+		Assert.Equal(authenticateSuccess, !clientConnectTask.IsFaulted);
 		if (!authenticateSuccess)
 		{
 			var serverEx = await Assert.ThrowsAsync<SshConnectionException>(() => serverConnectTask);

--- a/test/cs/Ssh.Test/SessionPair.cs
+++ b/test/cs/Ssh.Test/SessionPair.cs
@@ -37,8 +37,16 @@ class SessionPair : IDisposable
 		ServerStream = new MockNetworkStream(serverStream);
 		ClientStream = new MockNetworkStream(clientStream);
 
-		ServerKey = SshAlgorithms.PublicKey.ECDsaSha2Nistp384.GenerateKeyPair();
-		ClientKey = SshAlgorithms.PublicKey.ECDsaSha2Nistp384.GenerateKeyPair();
+		if (SshAlgorithms.PublicKey.ECDsaSha2Nistp384.IsAvailable)
+		{
+			ServerKey = SshAlgorithms.PublicKey.ECDsaSha2Nistp384.GenerateKeyPair();
+			ClientKey = SshAlgorithms.PublicKey.ECDsaSha2Nistp384.GenerateKeyPair();
+		}
+		else
+		{
+			ServerKey = SshAlgorithms.PublicKey.RsaWithSha256.GenerateKeyPair();
+			ClientKey = SshAlgorithms.PublicKey.RsaWithSha256.GenerateKeyPair();
+		}
 
 		ServerSession = new SshServerSession(serverConfig, disconnectedSessions, Trace);
 		ServerSession.Credentials = new[] { ServerKey };

--- a/test/cs/Ssh.Test/SessionTests.cs
+++ b/test/cs/Ssh.Test/SessionTests.cs
@@ -31,8 +31,11 @@ public class SessionTests : IDisposable
 		var config = new SshSessionConfiguration();
 
 #if SSH_ENABLE_AESGCM
-		config.EncryptionAlgorithms.Clear();
-		config.EncryptionAlgorithms.Add(SshAlgorithms.Encryption.Aes256Gcm);
+		if (SshAlgorithms.Encryption.Aes256Gcm.IsAvailable)
+		{
+			config.EncryptionAlgorithms.Clear();
+			config.EncryptionAlgorithms.Add(SshAlgorithms.Encryption.Aes256Gcm);
+		}
 #endif
 
 		this.sessionPair = new SessionPair(config);

--- a/test/ts/ssh-test/cryptoTests.ts
+++ b/test/ts/ssh-test/cryptoTests.ts
@@ -17,7 +17,7 @@ import {
 export class CryptoTests {
 	@test
 	@slow(5000)
-	@timeout(10000)
+	@timeout(20000)
 	@params({ kexAlg: 'diffie-hellman-group14-sha256' })
 	@params({ kexAlg: 'diffie-hellman-group16-sha512' })
 	@params({ kexAlg: 'ecdh-sha2-nistp521' })


### PR DESCRIPTION
 - Remove .NET Standard 2.0 and .NET Core 2.1 build and test targets, because .NET Core 2.1 is no longer supported.
 - Add .NET Framework 4.8 build and test targets, conditional on Windows OS
 - Change various code to be compatible with .NET Framework.
 - Reduce test failures caused by unavailable crypto algorithms (ECDH, AES-GCM). The crypto tests specific to those algorithms will still fail, but other test cases will fallback to always-available algorithms. This reduces confusion about the cause for many test failures, particularly on Mac OS.
 - Update YAML build definitions to target the appropriate .NET versions.