### PR TITLE
Add build step to link libssl on Mac OS

### DIFF
--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -1,4 +1,4 @@
-name: PR Build
+name: SSH Build & Test
 
 on:
   pull_request:
@@ -25,6 +25,12 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+
+      # On the Mac build machines, libssl 1.1 is installed
+      # but not linked in the path expected by .NET. Fix it now.
+      - name: Link libssl on Mac OS
+        run: ln -sn /usr/local/opt/openssl/lib/libssl.1.1.dylib /usr/local/lib/libssl.1.1.dylib
+        if: matrix.os == 'macOS-latest'
 
       - name: Install dotnet versions
         uses: actions/setup-dotnet@v2
@@ -77,15 +83,15 @@ jobs:
         run: npm run test-cs -- --release --serial --framework net48
         continue-on-error: true
 
+      - name: Start SSH debug session
+        uses: mxschmitt/action-tmate@v3
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
+        with:
+            limit-access-to-actor: true
+
       - name: Publish test results
         uses: dorny/test-reporter@v1
         with:
           name: Test SSH on ${{ matrix.os }}
           path: out/TestResults/*.trx
           reporter: dotnet-trx
-
-      - name: Start SSH debug session
-        uses: mxschmitt/action-tmate@v3
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
-        with:
-            limit-access-to-actor: true

--- a/.pipelines/dev-tunnels-ssh-ci.yaml
+++ b/.pipelines/dev-tunnels-ssh-ci.yaml
@@ -37,7 +37,7 @@ jobs:
         fetchDepth: -1
         clean: true
         fetchTags: false
-        
+
       - task: UseDotNet@2
         displayName: Install .NET Core 3.1 Runtime
         inputs:
@@ -219,6 +219,13 @@ jobs:
         fetchDepth: -1
         clean: true
         fetchTags: false
+
+      # On the Mac build machines, libssl 1.1 is installed
+      # but not linked in the path expected by .NET. Fix it now.
+      - task: CmdLine@2
+        displayName: Link libssl
+        inputs:
+          script: ln -sn /usr/local/opt/openssl/lib/libssl.1.1.dylib /usr/local/lib/libssl.1.1.dylib
 
       - task: UseDotNet@2
         displayName: Install .NET Core 3.1 Runtime


### PR DESCRIPTION
This fixes the ECDH and AES-GCM tests that have been failing on Mac OS build workflows because `libssl` was not found.