### PR TITLE
Add step to build pipeline to use Nuget 6.4.0

### DIFF
--- a/.pipelines/dev-tunnels-ssh-ci.yaml
+++ b/.pipelines/dev-tunnels-ssh-ci.yaml
@@ -75,6 +75,11 @@ jobs:
         inputs:
           verbose: false
       
+      - task: NuGetToolInstaller@1
+        displayName: Use NuGet 6.4.0
+        inputs:
+          versionSpec: '6.4.0'
+      
       # To archive our debug symbols wiht symweb, we need to convert the portable .pdb files that we build to windows .pdb files first
       # https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki/672/Archive-Symbols-with-Symweb?anchor=portable-pdbs
       - task: NuGetCommand@2


### PR DESCRIPTION
Specifying an appropriate version of the nuget CLI so that we can publish .snupkg files.

See this analogous PR: https://github.com/microsoft/dev-tunnels/pull/184