### PR TITLE
remove snupkg from nuget push

### DIFF
--- a/.pipelines/dev-tunnels-ssh-ci.yaml
+++ b/.pipelines/dev-tunnels-ssh-ci.yaml
@@ -190,7 +190,7 @@ jobs:
         continueOnError: True
         inputs:
           command: push
-          searchPatternPush: out/pkg/*.nupkg;out/pkg/*.snupkg
+          searchPatternPush: out/pkg/*.nupkg
           nuGetFeedType: external
           publishFeedCredentials: 'dev-tunnels-nuget'
           publishPackageMetadata: true


### PR DESCRIPTION
## What's the issue?
Our Nuget publish step is failing because Nuget is rejecting duplicate attempts to publish .snupkg:
```
D:\a\_work\_tool\NuGet\6.4.0\x64\nuget.exe push D:\a\_work\1\s\out\pkg\Microsoft.DevTunnels.Ssh.3.10.18.nupkg -NonInteractive -Source https://api.nuget.org/v3/index.json -ApiKey *** -ConfigFile D:\a\_work\1\Nuget\tempNuGet_7266511.config -Verbosity Detailed
NuGet Version: 6.4.0.123
Pushing Microsoft.DevTunnels.Ssh.3.10.18.nupkg to 'https://www.nuget.org/api/v2/package'...
  PUT https://www.nuget.org/api/v2/package/
WARNING: Readme missing. Go to https://learn.microsoft.com/nuget/create-packages/package-authoring-best-practices#readme learn How to include a readme file within the package.
  Created https://www.nuget.org/api/v2/package/ 773ms
Your package was pushed.
Pushing Microsoft.DevTunnels.Ssh.3.10.18.snupkg to 'https://www.nuget.org/api/v2/symbolpackage'...
  PUT https://www.nuget.org/api/v2/symbolpackage/
  Created https://www.nuget.org/api/v2/symbolpackage/ 422ms
Your package was pushed.
D:\a\_work\_tool\NuGet\6.4.0\x64\nuget.exe push D:\a\_work\1\s\out\pkg\Microsoft.DevTunnels.Ssh.3.10.18.snupkg -NonInteractive -Source https://api.nuget.org/v3/index.json -ApiKey *** -ConfigFile D:\a\_work\1\Nuget\tempNuGet_7266511.config -Verbosity Detailed
Response status code does not indicate success: 409 (It looks like there is another copy of this symbols package pending validation(s). Please wait for the validation(s) to finish before trying to replace the symbols package.).
```

This PR reverts one line of [this PR](https://github.com/microsoft/dev-tunnels-ssh/commit/a76ff1386cac263f5fba1ffc09fb57d8806230ea).

## Why was it happening?
[These docs](https://learn.microsoft.com/en-us/nuget/create-packages/symbol-packages-snupkg#publishing-a-symbol-package) suggest that it is sufficient to specify the .nupkg only:

```
You can also push both primary and symbol packages at the same time using the below command. Both .nupkg and .snupkg files need to be present in the current folder.
```

## Why didn't we see this earlier?
Earlier runs of our pipeline **did not** publish snupkg files, even though they were already being generated in the same place for this repo. Here is an example:
```
D:\a\_work\_tool\NuGet\4.1.0\x64\nuget.exe push D:\a\_work\1\a\Microsoft.DevTunnels.Connections.1.0.7349.nupkg -NonInteractive -Source https://api.nuget.org/v3/index.json -ApiKey *** -ConfigFile D:\a\_work\1\Nuget\tempNuGet_7176802.config -Verbosity Detailed
NuGet Version: 4.1.0.2450
Pushing Microsoft.DevTunnels.Connections.1.0.7349.nupkg to 'https://www.nuget.org/api/v2/package'...
  PUT https://www.nuget.org/api/v2/package/
  Created https://www.nuget.org/api/v2/package/ 785ms
Your package was pushed.
```
I believe this is because that run was using an earlier version of Nuget (4.1.0). We recently upgraded to Nuget 6.4 [here](https://github.com/microsoft/dev-tunnels-ssh/commit/d5711e087b1d636c30084f1f6ea867c5a2a48c2c), which I believe caused the .snupkg files to be picked up as part of the *.nupkg search pattern.