### PR TITLE
Add license and author to ts packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
 	"packages": {
 		"": {
 			"name": "@microsoft/dev-tunnels-ssh",
+			"license": "MIT",
 			"dependencies": {
 				"buffer": "^5.2.1",
 				"diffie-hellman": "^5.0.3",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
 		"SSH"
 	],
 	"author": "Microsoft",
+	"license": "MIT",
 	"main": "out/lib/ssh/index.js",
 	"scripts": {
 		"build": "node ./build.js build",

--- a/src/ts/ssh-keys/LICENSE
+++ b/src/ts/ssh-keys/LICENSE
@@ -1,0 +1,21 @@
+    MIT License
+
+    Copyright (c) Microsoft Corporation.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE

--- a/src/ts/ssh-keys/package.json
+++ b/src/ts/ssh-keys/package.json
@@ -5,6 +5,8 @@
 	"keywords": [
 		"SSH"
 	],
+	"author": "Microsoft",
+	"license": "MIT",
 	"scripts": {
 		"compile": "npm run -C ../../.. compile",
 		"eslint": "npm run -C ../../.. eslint",

--- a/src/ts/ssh-tcp/LICENSE
+++ b/src/ts/ssh-tcp/LICENSE
@@ -1,0 +1,21 @@
+    MIT License
+
+    Copyright (c) Microsoft Corporation.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE

--- a/src/ts/ssh-tcp/package.json
+++ b/src/ts/ssh-tcp/package.json
@@ -5,6 +5,8 @@
 	"keywords": [
 		"SSH"
 	],
+	"author": "Microsoft",
+	"license": "MIT",
 	"scripts": {
 		"compile": "npm run -C ../../.. compile",
 		"eslint": "npm run -C ../../.. eslint",

--- a/src/ts/ssh/LICENSE
+++ b/src/ts/ssh/LICENSE
@@ -1,0 +1,21 @@
+    MIT License
+
+    Copyright (c) Microsoft Corporation.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE

--- a/src/ts/ssh/package.json
+++ b/src/ts/ssh/package.json
@@ -6,6 +6,8 @@
 	"keywords": [
 		"SSH"
 	],
+	"author": "Microsoft",
+	"license": "MIT",
 	"scripts": {
 		"compile": "npm run -C ../../.. compile",
 		"eslint": "npm run -C ../../.. eslint",


### PR DESCRIPTION
Fix for CG alert https://devdiv.visualstudio.com/DefaultCollection/OnlineServices/_workitems/edit/1639780/

## Changes
- Add "license": "MIT" and "author": "Microsoft" to `package.json` files
- Add LICENSE file to package folders