### PR TITLE
Bump dotnet SDK to 6.0.405

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
 	"sdk": {
-		"version": "6.0.100",
+		"version": "6.0.405",
 		"rollForward": "latestFeature"
 	}
 }


### PR DESCRIPTION
here are CG alerts about vulnerable service images. The fix is to use latest ones and those have asp.net runtime 6.0.13 that uses 6.0.5 SDK. To be consistent, bump SDK version in the dev-tunnels-ssh as well.