### PR TITLE
Support ignore message in typescript and cs SDK

### DIFF
--- a/src/cs/Ssh/SshSession.cs
+++ b/src/cs/Ssh/SshSession.cs
@@ -886,6 +886,7 @@ public class SshSession : IDisposable
 			AuthenticationMessage m => HandleMessageAsync(m, cancellation),
 			ConnectionMessage m => HandleMessageAsync(m, cancellation),
 			DebugMessage m => HandleMessageAsync(m, cancellation),
+			IgnoreMessage m => HandleMessageAsync(m, cancellation),
 			UnimplementedMessage m => HandleMessageAsync(m, cancellation),
 			_ => throw (message == null
 				? new ArgumentNullException(nameof(message))
@@ -898,7 +899,7 @@ public class SshSession : IDisposable
 		DisconnectMessage message, CancellationToken cancellation)
 	{
 		cancellation.ThrowIfCancellationRequested();
-
+ 
 		var description = !string.IsNullOrEmpty(message.Description) ? message.Description :
 			"Received disconnect message.";
 		await CloseAsync(message.ReasonCode, description).ConfigureAwait(false);
@@ -999,6 +1000,15 @@ public class SshSession : IDisposable
 			message.AlwaysDisplay ? TraceEventType.Information : TraceEventType.Verbose,
 			SshTraceEventIds.DebugMessage,
 			message.Message);
+		return Task.CompletedTask;
+	}
+
+#pragma warning disable CA1801, CA1822 // Review unused parameters, can be static
+	private Task HandleMessageAsync(
+		IgnoreMessage message,
+		CancellationToken cancellation)
+#pragma warning restore CA1801, CA1822 // Review unused parameters, can be static
+	{
 		return Task.CompletedTask;
 	}
 

--- a/src/ts/ssh/sshSession.ts
+++ b/src/ts/ssh/sshSession.ts
@@ -35,6 +35,7 @@ import {
 	ServiceAcceptMessage,
 	UnimplementedMessage,
 	DebugMessage,
+	IgnoreMessage,
 } from './messages/transportMessages';
 import { SessionMetrics } from './metrics/sessionMetrics';
 import { PromiseCompletionSource } from './util/promiseCompletionSource';
@@ -568,6 +569,9 @@ export class SshSession implements Disposable {
 			return this.handleUnimplementedMessage(message, cancellation);
 		} else if (message instanceof DebugMessage) {
 			return this.handleDebugMessage(message);
+		} else if (message instanceof IgnoreMessage) {
+			// Do nothing for ignore message
+			return;
 		} else if (message instanceof SshMessage) {
 			throw new Error(`Unhandled message type: ${message.constructor.name}`);
 		} else {


### PR DESCRIPTION
We have seen an [issue](https://github.com/microsoft/basis-planning/issues/685) with Codespaces where using JetBrains Gateway while connecting with Java SDK for forwarding port and the IDE repeatedly restarts. This is happening because Java SDK sends SSH Ignore message and we do not handle it properly in our CS SSH layer.