### PR TITLE
Activate connection service after kex 'none'

### DIFF
--- a/src/cs/Ssh/Services/KeyExchangeService.cs
+++ b/src/cs/Ssh/Services/KeyExchangeService.cs
@@ -201,6 +201,10 @@ internal class KeyExchangeService : SshService
 				SshTraceEventIds.AlgorithmNegotiation,
 				$"Client and server negotiated no security. Cancelling key-exchange.");
 
+			// The connection service is normally activated after authentication. But when there is
+			// no key-exchange there will be no authentication, so connections must be enabled now.
+			Session.ActivateService<ConnectionService>();
+
 			this.exchangeContext.NewAlgorithms = new SshSessionAlgorithms();
 			await Session.HandleMessageAsync(new NewKeysMessage(), cancellation)
 				.ConfigureAwait(false);

--- a/src/cs/Ssh/SshSession.cs
+++ b/src/cs/Ssh/SshSession.cs
@@ -899,7 +899,7 @@ public class SshSession : IDisposable
 		DisconnectMessage message, CancellationToken cancellation)
 	{
 		cancellation.ThrowIfCancellationRequested();
- 
+
 		var description = !string.IsNullOrEmpty(message.Description) ? message.Description :
 			"Received disconnect message.";
 		await CloseAsync(message.ReasonCode, description).ConfigureAwait(false);
@@ -915,7 +915,8 @@ public class SshSession : IDisposable
 		else if (!(message is KeyExchangeInitMessage initMessage && initMessage.AllowsNone))
 		{
 			// The other side required some security, but it's not configured here.
-			await CloseAsync(SshDisconnectReason.KeyExchangeFailed).ConfigureAwait(false);
+			await CloseAsync(SshDisconnectReason.KeyExchangeFailed, "Encryption is disabled.")
+				.ConfigureAwait(false);
 		}
 	}
 

--- a/src/ts/ssh/services/keyExchangeService.ts
+++ b/src/ts/ssh/services/keyExchangeService.ts
@@ -30,6 +30,7 @@ import { SshConnectionError } from '../errors';
 import { SshDisconnectReason } from '../messages/transportMessages';
 import { SshSessionAlgorithms } from '../sshSessionAlgorithms';
 import { CancellationToken } from 'vscode-jsonrpc';
+import { ConnectionService } from './connectionService';
 import { serviceActivation } from './serviceActivation';
 import { SshTraceEventIds, TraceLevel } from '../trace';
 
@@ -206,6 +207,10 @@ export class KeyExchangeService extends SshService {
 				SshTraceEventIds.algorithmNegotiation,
 				'Client and server negotiated no security. Cancelling key-exchange.',
 			);
+
+			// The connection service is normally activated after authentication. But when there is
+			// no key-exchange there will be no authentication, so connections must be enabled now.
+			this.session.activateService(ConnectionService);
 
 			this.exchangeContext.newAlgorithms = new SshSessionAlgorithms();
 			await this.session.handleNewKeysMessage(new NewKeysMessage(), cancellation);

--- a/src/ts/ssh/sshSession.ts
+++ b/src/ts/ssh/sshSession.ts
@@ -695,7 +695,7 @@ export class SshSession implements Disposable {
 			await this.kexService.handleMessage(message, cancellation);
 		} else if (!(message instanceof KeyExchangeInitMessage && message.allowsNone)) {
 			// The other side required some security, but it's not configured here.
-			await this.close(SshDisconnectReason.keyExchangeFailed);
+			await this.close(SshDisconnectReason.keyExchangeFailed, 'Encryption is disabled.');
 		}
 	}
 


### PR DESCRIPTION
This is a small fix for the following bug: If SSH client and server negotiate 'none' as the key-exchange algorithm, that also implies no encryption and no authentication following key-exchange. Then when either side receives a channel open request, it will be rejected because the internal SSH connection service was not activated. Normally the connection service does not get activated until successful authentication, because in a secure session no channels are allowed to be opened until then.

The `MultiChannelStream` always disables key-exchange; it is able to connect because internally it explicitly activates the connection service. This bug deals with use of `SshSession` classes with 'none` key-exchange algorithm _without_ `MultiChannelStream`. In that case there was no way to explicitly activate the connection service because it isn't public.