### PR TITLE
SSH message factory for port-forwarding

### DIFF
--- a/src/cs/Ssh.Tcp/DefaultPortForwardMessageFactory.cs
+++ b/src/cs/Ssh.Tcp/DefaultPortForwardMessageFactory.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using System.Threading.Tasks;
+using Microsoft.DevTunnels.Ssh.Messages;
+
+namespace Microsoft.DevTunnels.Ssh.Tcp;
+
+internal class DefaultPortForwardMessageFactory : IPortForwardMessageFactory
+{
+	public Task<PortForwardRequestMessage> CreateRequestMessageAsync(int port) =>
+		Task.FromResult(new PortForwardRequestMessage());
+	public Task<PortForwardSuccessMessage> CreateSuccessMessageAsync(int port) =>
+		Task.FromResult(new PortForwardSuccessMessage());
+	public Task<PortForwardChannelOpenMessage> CreateChannelOpenMessageAsync(int port) =>
+		Task.FromResult(new PortForwardChannelOpenMessage());
+}

--- a/src/cs/Ssh.Tcp/IPortForwardMessageFactory.cs
+++ b/src/cs/Ssh.Tcp/IPortForwardMessageFactory.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using System.Threading.Tasks;
+using Microsoft.DevTunnels.Ssh.Messages;
+
+namespace Microsoft.DevTunnels.Ssh.Tcp;
+
+/// <summary>
+/// Enables applications to extend port-forwarding by providing custom message subclasses
+/// that may include additional properties.
+/// </summary>
+/// <remarks>
+/// Custom message subclasses must override <see cref="SshMessage.OnRead" /> and
+/// <see cref="SshMessage.OnWrite" /> to handle serialization of any additional properties.
+/// </remarks>
+public interface IPortForwardMessageFactory
+{
+	/// <summary>
+	/// Creates a message for requesting to forward a port.
+	/// </summary>
+	/// <returns>An instance or subclass of <see cref="PortForwardRequestMessage" />.</returns>
+	Task<PortForwardRequestMessage> CreateRequestMessageAsync(int port);
+
+	/// <summary>
+	/// Creates a message for a succesful response to a port-forward request.
+	/// </summary>
+	/// <returns>An instance or subclass of <see cref="PortForwardSuccessMessage" />.</returns>
+	Task<PortForwardSuccessMessage> CreateSuccessMessageAsync(int port);
+
+	/// <summary>
+	/// Creates a message requesting to open a channel for a forwarded port.
+	/// </summary>
+	/// <returns>An instance or subclass of <see cref="PortForwardChannelOpenMessage" />.</returns>
+	Task<PortForwardChannelOpenMessage> CreateChannelOpenMessageAsync(int port);
+}

--- a/src/cs/Ssh.Tcp/IPortForwardMessageFactory.cs
+++ b/src/cs/Ssh.Tcp/IPortForwardMessageFactory.cs
@@ -18,18 +18,26 @@ public interface IPortForwardMessageFactory
 	/// <summary>
 	/// Creates a message for requesting to forward a port.
 	/// </summary>
+	/// <param name="port">The port number that is requested, or 0 if a random port is requested.
+	/// (The other side may choose a different port if the requested port is in use.)</param>
 	/// <returns>An instance or subclass of <see cref="PortForwardRequestMessage" />.</returns>
 	Task<PortForwardRequestMessage> CreateRequestMessageAsync(int port);
 
 	/// <summary>
 	/// Creates a message for a succesful response to a port-forward request.
 	/// </summary>
+	/// <param name="port">The port number that was requested by the other side. This may be
+	/// different from the local port that was chosen. Or if the other side requested a random
+	/// port then the actual chosen port number is returned in the success message.</param>
 	/// <returns>An instance or subclass of <see cref="PortForwardSuccessMessage" />.</returns>
 	Task<PortForwardSuccessMessage> CreateSuccessMessageAsync(int port);
 
 	/// <summary>
 	/// Creates a message requesting to open a channel for a forwarded port.
 	/// </summary>
+	/// <param name="port">The port number that the channel will connect to. All channel messages
+	/// use the originally requested port number, which may be different from the actual TCP socket
+	/// port number if the requested port was in use at the time of the forward request.</param>
 	/// <returns>An instance or subclass of <see cref="PortForwardChannelOpenMessage" />.</returns>
 	Task<PortForwardChannelOpenMessage> CreateChannelOpenMessageAsync(int port);
 }

--- a/src/cs/Ssh.Tcp/Services/PortForwardingService.cs
+++ b/src/cs/Ssh.Tcp/Services/PortForwardingService.cs
@@ -585,11 +585,12 @@ public class PortForwardingService : SshService
 					{
 						// The chosen local port may be different from the requested port. Use the
 						// requested port in the response, unless the request was for a random port.
-						response = new PortForwardSuccessMessage
-						{
-							Port = portForwardRequest.Port == 0 ? (uint)localPort.Value :
-								portForwardRequest.Port,
-						};
+						var forwardedPort = portForwardRequest.Port == 0 ? (uint)localPort.Value :
+								portForwardRequest.Port;
+						var portResponse = await this.MessageFactory.CreateSuccessMessageAsync(
+							(int)forwardedPort).ConfigureAwait(false);
+						portResponse.Port = forwardedPort;
+						response = portResponse;
 					}
 				}
 				else if (request.RequestType == CancelPortForwardRequestType)

--- a/src/cs/Ssh.Tcp/Services/RemotePortConnector.cs
+++ b/src/cs/Ssh.Tcp/Services/RemotePortConnector.cs
@@ -41,18 +41,17 @@ public abstract class RemotePortConnector : SshService
 	/// </remarks>
 	public int RemotePort { get; private set; }
 
-	internal async Task<bool> RequestAsync(CancellationToken cancellation)
+	internal async Task<bool> RequestAsync(
+		PortForwardRequestMessage request,
+		CancellationToken cancellation)
 	{
 		if (this.forwarding)
 		{
 			throw new InvalidOperationException("Already forwarding.");
 		}
 
-		var request = new PortForwardRequestMessage
-		{
-			AddressToBind = IPAddressConversions.ToString(RemoteIPAddress),
-			Port = (uint)RemotePort,
-		};
+		request.AddressToBind = IPAddressConversions.ToString(RemoteIPAddress);
+		request.Port = (uint)RemotePort;
 
 		var response = await Session.RequestAsync<PortForwardSuccessMessage>(
 			request, cancellation).ConfigureAwait(false);

--- a/src/ts/ssh-tcp/index.ts
+++ b/src/ts/ssh-tcp/index.ts
@@ -11,6 +11,7 @@ export { PortForwardingService } from './services/portForwardingService';
 export { LocalPortForwarder } from './services/localPortForwarder';
 export { RemotePortForwarder } from './services/remotePortForwarder';
 export { RemotePortStreamer } from './services/remotePortStreamer';
+export { PortForwardMessageFactory } from './portForwardMessageFactory';
 
 export { PortForwardRequestMessage } from './messages/portForwardRequestMessage';
 export { PortForwardSuccessMessage } from './messages/portForwardSuccessMessage';

--- a/src/ts/ssh-tcp/portForwardMessageFactory.ts
+++ b/src/ts/ssh-tcp/portForwardMessageFactory.ts
@@ -1,0 +1,44 @@
+import { PortForwardChannelOpenMessage } from './messages/portForwardChannelOpenMessage';
+import { PortForwardRequestMessage } from './messages/portForwardRequestMessage';
+import { PortForwardSuccessMessage } from './messages/portForwardSuccessMessage';
+
+/**
+ * Enables applications to extend port-forwarding by providing custom message subclasses
+ * that may include additional properties.
+ *
+ * Custom message subclasses must override `SshMessage.onRead` and `SshMessage.onWrite`
+ * to handle serialization of any additional properties.
+ */
+export interface PortForwardMessageFactory {
+	/**
+	 * Creates a message for requesting to forward a port.
+	 * @returns An instance or subclass of `PortForwardRequestMessage`.
+	 */
+	createRequestMessageAsync(port: number): Promise<PortForwardRequestMessage>;
+
+	/**
+	 * Creates a message for a succesful response to a port-forward request.
+	 * @returns An instance or subclass of `PortForwardSuccessMessage`.
+	 */
+	createSuccessMessageAsync(port: number): Promise<PortForwardSuccessMessage>;
+
+	/**
+	 * Creates a message requesting to open a channel for a forwarded port.
+	 * @returns An instance or subclass of `PortForwardChannelOpenMessage`.
+	 */
+	createChannelOpenMessageAsync(port: number): Promise<PortForwardChannelOpenMessage>;
+}
+
+export class DefaultPortForwardMessageFactory {
+	public createRequestMessageAsync(port: number): Promise<PortForwardRequestMessage> {
+		return Promise.resolve(new PortForwardRequestMessage());
+	}
+
+	public createSuccessMessageAsync(port: number): Promise<PortForwardSuccessMessage> {
+		return Promise.resolve(new PortForwardSuccessMessage());
+	}
+
+	public createChannelOpenMessageAsync(port: number): Promise<PortForwardChannelOpenMessage> {
+		return Promise.resolve(new PortForwardChannelOpenMessage());
+	}
+}

--- a/src/ts/ssh-tcp/portForwardMessageFactory.ts
+++ b/src/ts/ssh-tcp/portForwardMessageFactory.ts
@@ -12,18 +12,26 @@ import { PortForwardSuccessMessage } from './messages/portForwardSuccessMessage'
 export interface PortForwardMessageFactory {
 	/**
 	 * Creates a message for requesting to forward a port.
+	 * @param port The port number that is requested, or 0 if a random port is requested.
+	 * (The other side may choose a different port if the requested port is in use.)
 	 * @returns An instance or subclass of `PortForwardRequestMessage`.
 	 */
 	createRequestMessageAsync(port: number): Promise<PortForwardRequestMessage>;
 
 	/**
 	 * Creates a message for a succesful response to a port-forward request.
+	 * @param port The port number that was requested by the other side. This may be different
+	 * from the local port that was chosen. Or if the other side requested a random port then
+	 * the actual chosen port number is returned in the success message.
 	 * @returns An instance or subclass of `PortForwardSuccessMessage`.
 	 */
 	createSuccessMessageAsync(port: number): Promise<PortForwardSuccessMessage>;
 
 	/**
 	 * Creates a message requesting to open a channel for a forwarded port.
+	 * @param port The port number that the channel will connect to. All channel messages use
+	 * the originally requested port number, which may be different from the actual TCP socket
+	 * port number if the requested port was in use at the time of the forward request.
 	 * @returns An instance or subclass of `PortForwardChannelOpenMessage`.
 	 */
 	createChannelOpenMessageAsync(port: number): Promise<PortForwardChannelOpenMessage>;

--- a/src/ts/ssh-tcp/services/portForwardingService.ts
+++ b/src/ts/ssh-tcp/services/portForwardingService.ts
@@ -30,6 +30,10 @@ import { PortForwardChannelOpenMessage } from '../messages/portForwardChannelOpe
 import { PortForwardRequestMessage } from '../messages/portForwardRequestMessage';
 import { PortForwardSuccessMessage } from '../messages/portForwardSuccessMessage';
 import { TcpListenerFactory, DefaultTcpListenerFactory } from '../tcpListenerFactory';
+import {
+	PortForwardMessageFactory,
+	DefaultPortForwardMessageFactory,
+} from '../portForwardMessageFactory';
 import { ChannelForwarder } from './channelForwarder';
 import { LocalPortForwarder } from './localPortForwarder';
 import { RemotePortConnector } from './remotePortConnector';
@@ -165,6 +169,14 @@ export class PortForwardingService extends SshService {
 	public tcpListenerFactory: TcpListenerFactory = new DefaultTcpListenerFactory();
 
 	/**
+	 * Gets or sets a factory for creating port-forwarding messages.
+	 *
+	 * A message factory enables applications to extend port-forwarding by providing custom
+	 * message subclasses that may include additional properties.
+	 */
+	public messageFactory: PortForwardMessageFactory = new DefaultPortForwardMessageFactory();
+
+	/**
 	 * Sends a request to the remote side to listen on a port and forward incoming connections
 	 * as SSH channels of type 'forwarded-tcpip', which will then be relayed to the same port
 	 * number on the local side.
@@ -250,7 +262,9 @@ export class PortForwardingService extends SshService {
 			localHost,
 			localPort,
 		);
-		if (!(await forwarder.request(cancellation))) {
+
+		const request = await this.messageFactory.createRequestMessageAsync(remotePort);
+		if (!(await forwarder.request(request, cancellation))) {
 			forwarder.dispose();
 			return null;
 		}
@@ -388,7 +402,8 @@ export class PortForwardingService extends SshService {
 		}
 
 		const streamer = new RemotePortStreamer(this.session, remoteIPAddress, remotePort);
-		if (!(await streamer.request(cancellation))) {
+		const request = await this.messageFactory.createRequestMessageAsync(remotePort);
+		if (!(await streamer.request(request, cancellation))) {
 			streamer.dispose();
 			return null;
 		}
@@ -587,9 +602,12 @@ export class PortForwardingService extends SshService {
 				if (localPort !== null) {
 					// The chosen local port may be different from the requested port. Use the
 					// requested port in the response, unless the request was for a random port.
-					const portResponse = new PortForwardSuccessMessage();
-					portResponse.port =
+					const forwardedPort =
 						portForwardRequest.port === 0 ? localPort : portForwardRequest.port;
+					const portResponse = await this.messageFactory.createSuccessMessageAsync(
+						forwardedPort,
+					);
+					portResponse.port = forwardedPort;
 					response = portResponse;
 				}
 			} else if (request.requestType === PortForwardingService.cancelPortForwardRequestType) {
@@ -785,7 +803,7 @@ export class PortForwardingService extends SshService {
 			}
 		}
 
-		const openMessage = new PortForwardChannelOpenMessage();
+		const openMessage = await this.messageFactory.createChannelOpenMessageAsync(port);
 		openMessage.channelType = channelType;
 		openMessage.originatorIPAddress = originatorIPAddress ?? '';
 		openMessage.originatorPort = originatorPort ?? 0;

--- a/src/ts/ssh-tcp/services/remotePortConnector.ts
+++ b/src/ts/ssh-tcp/services/remotePortConnector.ts
@@ -41,12 +41,14 @@ export class RemotePortConnector extends SshService {
 	}
 
 	/* @internal */
-	public async request(cancellation?: CancellationToken): Promise<boolean> {
+	public async request(
+		request: PortForwardRequestMessage,
+		cancellation?: CancellationToken,
+	): Promise<boolean> {
 		if (this.forwarding) {
 			throw new Error('Already forwarding.');
 		}
 
-		const request = new PortForwardRequestMessage();
 		request.addressToBind = this.remoteIPAddress;
 		request.port = this.remotePort;
 		request.wantReply = true;


### PR DESCRIPTION
A message factory interface for the SSH port-forwarding service will enable the dev-tunnels SDK to extend port-forwarding messages with additional properties to support more functionality and fine-grained access control.