### PR TITLE
Allow ConnectToForwardedPort to return a forwarded stream without opening a TCP connection

### DIFF
--- a/src/cs/Ssh.Tcp/Services/PortForwardingService.cs
+++ b/src/cs/Ssh.Tcp/Services/PortForwardingService.cs
@@ -788,7 +788,8 @@ public class PortForwardingService : SshService
 
 		request.FailureReason = portForwardRequest.FailureReason;
 		request.FailureDescription = portForwardRequest.FailureDescription;
-		if (request.FailureReason != SshChannelOpenFailureReason.None || !request.IsRemoteRequest)
+		if (request.FailureReason != SshChannelOpenFailureReason.None ||
+			!request.IsRemoteRequest || !AcceptLocalConnectionsForForwardedPorts)
 		{
 			return;
 		}

--- a/src/cs/Ssh.Tcp/Services/PortForwardingService.cs
+++ b/src/cs/Ssh.Tcp/Services/PortForwardingService.cs
@@ -85,6 +85,20 @@ public class PortForwardingService : SshService
 	public bool AcceptLocalConnectionsForForwardedPorts { get; set; } = true;
 
 	/// <summary>
+	/// Gets or sets a value that controls whether the port-forwarding service forwards connections
+	/// to local TCP sockets.
+	/// </summary>
+	/// <remarks>
+	/// The default is true.
+	/// <para/>
+	/// This property is typically initialized before connecting a session (if not keeping the
+	/// default). It may be changed at any time while the session is connected, and the new value
+	/// will affect any newly forwarded ports after that, but not previously-forwarded ports.
+	/// <para/>
+	/// </remarks>
+	public bool ForwardConnectionsToLocalPorts { get; set; } = true;
+
+	/// <summary>
 	/// Gets or sets a value that controls whether the port-forwarding service accepts
 	/// 'direct-tcpip' channel open requests and forwards the channel connections to the local port.
 	/// </summary>
@@ -789,7 +803,7 @@ public class PortForwardingService : SshService
 		request.FailureReason = portForwardRequest.FailureReason;
 		request.FailureDescription = portForwardRequest.FailureDescription;
 		if (request.FailureReason != SshChannelOpenFailureReason.None ||
-			!request.IsRemoteRequest || !AcceptLocalConnectionsForForwardedPorts)
+			!request.IsRemoteRequest || !ForwardConnectionsToLocalPorts)
 		{
 			return;
 		}

--- a/src/ts/ssh-tcp/services/portForwardingService.ts
+++ b/src/ts/ssh-tcp/services/portForwardingService.ts
@@ -108,7 +108,6 @@ export class PortForwardingService extends SshService {
 	 */
 	public acceptLocalConnectionsForForwardedPorts: boolean = true;
 
-
 	/**
 	 * Gets or sets a value that controls whether the port-forwarding service forwards connections
 	 * to local TCP sockets.
@@ -119,7 +118,7 @@ export class PortForwardingService extends SshService {
 	 * default). It may be changed at any time while the session is connected, and the new value
 	 * will affect any newly forwarded ports after that, but not previously-forwarded ports.
 	 */
-	public forwardConnectionsToLocalPorts : boolean = true;
+	public forwardConnectionsToLocalPorts: boolean = true;
 
 	/**
 	 * Gets or sets a value that controls whether the port-forwarding service accepts

--- a/src/ts/ssh-tcp/services/portForwardingService.ts
+++ b/src/ts/ssh-tcp/services/portForwardingService.ts
@@ -108,6 +108,19 @@ export class PortForwardingService extends SshService {
 	 */
 	public acceptLocalConnectionsForForwardedPorts: boolean = true;
 
+
+	/**
+	 * Gets or sets a value that controls whether the port-forwarding service forwards connections
+	 * to local TCP sockets.
+	 *
+	 * The default is true.
+	 *
+	 * This property is typically initialized before connecting a session (if not keeping the
+	 * default). It may be changed at any time while the session is connected, and the new value
+	 * will affect any newly forwarded ports after that, but not previously-forwarded ports.
+	 */
+	public forwardConnectionsToLocalPorts : boolean = true;
+
 	/**
 	 * Gets or sets a value that controls whether the port-forwarding service accepts
 	 * 'direct-tcpip' channel open requests and forwards the channel connections to the local port.
@@ -757,7 +770,7 @@ export class PortForwardingService extends SshService {
 		if (
 			request.failureReason !== SshChannelOpenFailureReason.none ||
 			!request.isRemoteRequest ||
-			!this.acceptLocalConnectionsForForwardedPorts
+			!this.forwardConnectionsToLocalPorts
 		) {
 			return;
 		}

--- a/src/ts/ssh-tcp/services/portForwardingService.ts
+++ b/src/ts/ssh-tcp/services/portForwardingService.ts
@@ -754,7 +754,8 @@ export class PortForwardingService extends SshService {
 
 		request.failureReason = portForwardRequest.failureReason;
 		request.failureDescription = portForwardRequest.failureDescription;
-		if (request.failureReason !== SshChannelOpenFailureReason.none || !request.isRemoteRequest) {
+		if (request.failureReason !== SshChannelOpenFailureReason.none ||
+			!request.isRemoteRequest || !this.acceptLocalConnectionsForForwardedPorts) {
 			return;
 		}
 

--- a/src/ts/ssh-tcp/services/portForwardingService.ts
+++ b/src/ts/ssh-tcp/services/portForwardingService.ts
@@ -754,8 +754,11 @@ export class PortForwardingService extends SshService {
 
 		request.failureReason = portForwardRequest.failureReason;
 		request.failureDescription = portForwardRequest.failureDescription;
-		if (request.failureReason !== SshChannelOpenFailureReason.none ||
-			!request.isRemoteRequest || !this.acceptLocalConnectionsForForwardedPorts) {
+		if (
+			request.failureReason !== SshChannelOpenFailureReason.none ||
+			!request.isRemoteRequest ||
+			!this.acceptLocalConnectionsForForwardedPorts
+		) {
 			return;
 		}
 

--- a/test/ts/ssh-test/portForwardingTests.ts
+++ b/test/ts/ssh-test/portForwardingTests.ts
@@ -1013,7 +1013,7 @@ export class PortForwardingTests {
 	}
 
 	@test
-	public async connectToForwardedPortWithoutStartingLocalServer() {
+	public async connectToForwardedPortWithoutForwardingConnectionToLocalPort() {
 		const testPort = await getAvailablePort();
 
 		const [clientSession, serverSession] = await this.createSessions();
@@ -1024,7 +1024,13 @@ export class PortForwardingTests {
 		});
 
 		const clientPfs = clientSession.activateService(PortForwardingService);
-		clientPfs.acceptLocalConnectionsForForwardedPorts = false;
+		clientPfs.forwardConnectionsToLocalPorts = false;
+
+		let localStream;
+		clientSession.onChannelOpening((e) => {
+			localStream = new SshStream(e.channel);
+        });
+
 		const serverPfs = serverSession.activateService(PortForwardingService);
 		serverPfs.acceptLocalConnectionsForForwardedPorts = false;
 
@@ -1040,7 +1046,8 @@ export class PortForwardingTests {
 			timeoutMs,
 		);
 
-		await forwardPromise;
+		assert(localStream);
+		assert(remoteStream);
 	}
 
 	@test


### PR DESCRIPTION
Allow ConnectToForwardedPort to return a forwarded stream without opening TCP connections to a TCP socket. 

- onChannelOpening do not forward channel if acceptLocalConnectionsForForwardedPorts is set to false
- add ConnectToForwardedPortWithoutStartingLocalServer tests