### PR TITLE
Activate connection service with kex disabled

### DIFF
--- a/src/cs/Ssh/MultiChannelStream.cs
+++ b/src/cs/Ssh/MultiChannelStream.cs
@@ -42,8 +42,6 @@ public class MultiChannelStream : IDisposable
 	private readonly Stream transportStream;
 	private readonly SshSession session;
 
-	private EventHandler<SshChannelOpeningEventArgs>? channelOpening;
-
 	/// <summary>
 	/// Creates a new multi-channel stream over an underlying transport stream.
 	/// </summary>
@@ -82,20 +80,7 @@ public class MultiChannelStream : IDisposable
 	/// Adding an event handler will activate the connection service on the session.
 	/// </remarks>
 	/// <exception cref="ObjectDisposedException">If a handler is added when the underlying ssh session is closed.</exception>
-	public event EventHandler<SshChannelOpeningEventArgs>? ChannelOpening
-	{
-		add
-		{
-			if (this.channelOpening == null && !IsClosed)
-			{
-				this.session.ActivateService<ConnectionService>();
-			}
-
-			this.channelOpening += value;
-		}
-
-		remove => this.channelOpening -= value;
-	}
+	public event EventHandler<SshChannelOpeningEventArgs>? ChannelOpening;
 
 	/// <summary>
 	/// Event that is rised when underlying ssh session is closed.
@@ -356,7 +341,7 @@ public class MultiChannelStream : IDisposable
 			e.Channel.MaxWindowSize = ChannelMaxWindowSize;
 		}
 
-		channelOpening?.Invoke(this, e);
+		ChannelOpening?.Invoke(this, e);
 	}
 
 	private void OnSessionClosed(object? sender, SshSessionClosedEventArgs e)

--- a/src/cs/Ssh/SshSession.cs
+++ b/src/cs/Ssh/SshSession.cs
@@ -82,6 +82,7 @@ public class SshSession : IDisposable
 
 			// No key exchange, no encryption, no HMAC.
 			this.kexService = null;
+			ActivateService<ConnectionService>();
 		}
 		else
 		{

--- a/src/ts/ssh/multiChannelStream.ts
+++ b/src/ts/ssh/multiChannelStream.ts
@@ -68,13 +68,7 @@ export class MultiChannelStream implements Disposable {
 	public readonly onClosed = this.closedEmitter.event;
 
 	private readonly channelOpeningEmitter = new Emitter<SshChannelOpeningEventArgs>();
-	public get onChannelOpening() {
-		if (!this.isClosed) {
-			this.session.activateService(ConnectionService);
-		}
-
-		return this.channelOpeningEmitter.event;
-	}
+	public readonly onChannelOpening = this.channelOpeningEmitter.event;
 
 	/**
 	 * Initiates the SSH session over the transport stream by exchanging initial messages with the

--- a/src/ts/ssh/sshSession.ts
+++ b/src/ts/ssh/sshSession.ts
@@ -185,6 +185,7 @@ export class SshSession implements Disposable {
 
 			// No key exchange, no encryption, no HMAC.
 			this.kexService = null;
+			this.activateService(ConnectionService);
 		} else {
 			this.kexService = new KeyExchangeService(this, isClientSession ?? false);
 		}


### PR DESCRIPTION
The [previous change to activate the connection service for 'none' key-exchange](https://github.com/microsoft/dev-tunnels-ssh/pull/35) was incomplete because the connection service was still never activated if the session configuration completely disabled algorithm negotiation.

This change enables using `SshSession` with algorithm negotiation disabled (`SshSessionConfiguration.NoSecurity`) _without_ using the `MultiChannelStream` class. And now there is no special code needed to activate that service in `MultiChannelStream`. 