### PR TITLE
Fix mac crypto tests

### DIFF
--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -29,7 +29,7 @@ jobs:
       # On the Mac build machines, libssl 1.1 is installed
       # but not linked in the path expected by .NET. Fix it now.
       - name: Link libssl on Mac OS
-        run: ln -sn /usr/local/opt/openssl/lib/libssl.1.1.dylib /usr/local/lib/libssl.1.1.dylib
+        run: ln -sn /usr/local/opt/openssl@1.1/lib/libssl.1.1.dylib /usr/local/lib/libssl.1.1.dylib
         if: matrix.os == 'macOS-latest'
 
       - name: Install dotnet versions

--- a/.pipelines/dev-tunnels-ssh-ci.yaml
+++ b/.pipelines/dev-tunnels-ssh-ci.yaml
@@ -247,7 +247,7 @@ jobs:
       - task: CmdLine@2
         displayName: Link libssl
         inputs:
-          script: ln -sn /usr/local/opt/openssl/lib/libssl.1.1.dylib /usr/local/lib/libssl.1.1.dylib
+          script: ln -sn /usr/local/opt/openssl@1.1/lib/libssl.1.1.dylib /usr/local/lib/libssl.1.1.dylib
 
       - task: UseDotNet@2
         displayName: Install .NET Core 3.1 Runtime


### PR DESCRIPTION
The tests had started failing because the default version of `openssl` / `libssl` on Mac was changed from 1.1 to 3.0. Version 1.1 is still installed but must be referenced by version.
