### PR TITLE
sshStream: add instanceof Uint8Array check to support browser Buffer polyfill

### DIFF
--- a/src/ts/ssh/sshStream.ts
+++ b/src/ts/ssh/sshStream.ts
@@ -19,8 +19,8 @@ export class SshStream extends Duplex {
 					let buffer: Buffer;
 					if (typeof chunk === 'string') {
 						buffer = Buffer.from(chunk, encoding);
-					} else if (chunk instanceof Buffer) {
-						buffer = chunk;
+					} else if (chunk instanceof Buffer || chunk instanceof Uint8Array) {
+						buffer = chunk as Buffer;
 					} else {
 						throw new Error('Unsupported chunk type: ' + typeof chunk);
 					}
@@ -46,7 +46,7 @@ export class SshStream extends Duplex {
 							accumulator: number,
 							chunk: { chunk: Buffer | string | any; encoding?: BufferEncoding },
 						): number {
-							if (chunk.chunk instanceof Buffer) {
+							if (chunk.chunk instanceof Buffer || chunk.chunk instanceof Uint8Array) {
 								return accumulator + chunk.chunk.length;
 							} else {
 								throw new Error('Unsupported chunk type: ' + typeof chunk.chunk);


### PR DESCRIPTION
Issue: sshStream is throwing an "Unsupported chunk type" exception in certain browser experiences due to node buffer polyfill returning a Uint8Array when calling Buffer.from(string),

Fix:
add instanceof Uint8Array check to support browser Buffer polyfill