### PR TITLE
Do not dispose SemaphoreSlim

### DIFF
--- a/src/cs/Ssh.Tcp/Services/ChannelForwarder.cs
+++ b/src/cs/Ssh.Tcp/Services/ChannelForwarder.cs
@@ -326,7 +326,13 @@ internal class ChannelForwarder : IDisposable
 			catch (ObjectDisposedException) { }
 			this.disposeCancellationSource.Dispose();
 
-			this.receiveSemaphore.Dispose();
+			// SemaphoreSlim.Dispose() is not thread-safe and may cause WaitAsync(CancellationToken) not being cancelled
+			// when SemaphoreSlim.Dispose is invoked immediately after CancellationTokenSource.Cancel.
+			// See https://github.com/dotnet/runtime/issues/59639
+			// SemaphoreSlim.Dispose() only disposes it's wait handle, which is not initialized unless its AvailableWaitHandle
+			// property is read, which we don't use.
+
+			// this.receiveSemaphore.Dispose();
 		}
 	}
 }

--- a/src/cs/Ssh/IO/SshProtocol.cs
+++ b/src/cs/Ssh/IO/SshProtocol.cs
@@ -31,7 +31,11 @@ internal class SshProtocol : IDisposable
 	private Stream? stream;
 	private readonly SshSessionConfiguration config;
 	private readonly SessionMetrics metrics;
+
+#pragma warning disable CA2213 // Disposable fields should be disposed
 	private readonly SemaphoreSlim sessionSemaphore;
+#pragma warning restore CA2213 // Disposable fields should be disposed
+
 	private readonly TraceSource trace;
 
 	private ulong inboundPacketSequence;

--- a/src/cs/Ssh/IO/SshProtocol.cs
+++ b/src/cs/Ssh/IO/SshProtocol.cs
@@ -852,6 +852,13 @@ internal class SshProtocol : IDisposable
 	{
 		this.Disconnect();
 		Algorithms?.Dispose();
-		this.sessionSemaphore.Dispose();
+
+		// SemaphoreSlim.Dispose() is not thread-safe and may cause WaitAsync(CancellationToken) not being cancelled
+		// when SemaphoreSlim.Dispose is invoked immediately after CancellationTokenSource.Cancel.
+		// See https://github.com/dotnet/runtime/issues/59639
+		// SemaphoreSlim.Dispose() only disposes it's wait handle, which is not initialized unless its AvailableWaitHandle
+		// property is read, which we don't use.
+
+		// this.sessionSemaphore.Dispose();
 	}
 }

--- a/src/cs/Ssh/SshChannel.cs
+++ b/src/cs/Ssh/SshChannel.cs
@@ -837,9 +837,17 @@ public class SshChannel : IDisposable
 		CancelPendingRequests();
 
 		this.connectionService.RemoveChannel(this);
-		this.sendSemaphore.Dispose();
-		this.sendingWindowSemaphore.Dispose();
-		this.channelRequestSemaphore.Dispose();
+
+		// SemaphoreSlim.Dispose() is not thread-safe and may cause WaitAsync(CancellationToken) not being cancelled
+		// when SemaphoreSlim.Dispose is invoked immediately after CancellationTokenSource.Cancel.
+		// See https://github.com/dotnet/runtime/issues/59639
+		// SemaphoreSlim.Dispose() only disposes it's wait handle, which is not initialized unless its AvailableWaitHandle
+		// property is read, which we don't use.
+
+		// this.sendSemaphore.Dispose();
+		// this.sendingWindowSemaphore.Dispose();
+		// this.channelRequestSemaphore.Dispose();
+
 		this.taskChain.Dispose();
 	}
 

--- a/src/cs/Ssh/SshChannel.cs
+++ b/src/cs/Ssh/SshChannel.cs
@@ -46,11 +46,15 @@ public class SshChannel : IDisposable
 	public const uint DefaultMaxWindowSize = DefaultMaxPacketSize * 32;
 
 	private readonly ConnectionService connectionService;
+
+#pragma warning disable CA2213 // Disposable fields should be disposed
 	private readonly SemaphoreSlim sendSemaphore = new SemaphoreSlim(0);
 	private readonly SemaphoreSlim sendingWindowSemaphore = new SemaphoreSlim(1);
+	private readonly SemaphoreSlim channelRequestSemaphore = new SemaphoreSlim(1);
+#pragma warning restore CA2213 // Disposable fields should be disposed
+
 	private readonly ConcurrentQueue<TaskCompletionSource<bool>> requestCompletionSources = new ();
 	private readonly TaskChain taskChain;
-	private readonly SemaphoreSlim channelRequestSemaphore = new SemaphoreSlim(1);
 
 	private uint remoteWindowSize;
 	private uint maxWindowSize;

--- a/src/cs/Ssh/SshSession.cs
+++ b/src/cs/Ssh/SshSession.cs
@@ -741,8 +741,15 @@ public class SshSession : IDisposable
 			Protocol?.Dispose();
 			Protocol = null;
 
-			this.blockedMessagesSemaphore.Dispose();
-			this.sessionRequestSemaphore.Dispose();
+			// SemaphoreSlim.Dispose() is not thread-safe and may cause WaitAsync(CancellationToken) not being cancelled
+			// when SemaphoreSlim.Dispose is invoked immediately after CancellationTokenSource.Cancel.
+			// See https://github.com/dotnet/runtime/issues/59639
+			// SemaphoreSlim.Dispose() only disposes it's wait handle, which is not initialized unless its AvailableWaitHandle
+			// property is read, which we don't use.
+
+			// this.blockedMessagesSemaphore.Dispose();
+			// this.sessionRequestSemaphore.Dispose();
+
 			this.taskChain.Dispose();
 		}
 	}

--- a/src/cs/Ssh/SshSession.cs
+++ b/src/cs/Ssh/SshSession.cs
@@ -29,7 +29,12 @@ public class SshSession : IDisposable
 {
 	private readonly ConcurrentQueue<SshMessage> blockedMessages =
 		new ConcurrentQueue<SshMessage>();
+
+#pragma warning disable CA2213 // Disposable fields should be disposed
 	private readonly SemaphoreSlim blockedMessagesSemaphore = new SemaphoreSlim(1);
+	private readonly SemaphoreSlim sessionRequestSemaphore = new SemaphoreSlim(1);
+#pragma warning restore CA2213 // Disposable fields should be disposed
+
 	private readonly ConcurrentDictionary<Type, SshService> services =
 		new ConcurrentDictionary<Type, SshService>();
 	private KeyExchangeService? kexService;
@@ -38,7 +43,6 @@ public class SshSession : IDisposable
 		new CancellationTokenSource();
 	private readonly ConcurrentQueue<IRequestHandler> requestHandlers = new ();
 	private readonly TaskChain taskChain;
-	private readonly SemaphoreSlim sessionRequestSemaphore = new SemaphoreSlim(1);
 	private Task? versionExchangeTask;
 	private Exception? closedException;
 

--- a/src/cs/Ssh/SshStream.cs
+++ b/src/cs/Ssh/SshStream.cs
@@ -188,7 +188,14 @@ public class SshStream : Stream
 			// Asynchronously close the channel, but don't wait for it.
 			_ = Channel.CloseAsync();
 
-			this.readSemaphore.Dispose();
+			// SemaphoreSlim.Dispose() is not thread-safe and may cause WaitAsync(CancellationToken) not being cancelled
+			// when SemaphoreSlim.Dispose is invoked immediately after CancellationTokenSource.Cancel.
+			// See https://github.com/dotnet/runtime/issues/59639
+			// SemaphoreSlim.Dispose() only disposes it's wait handle, which is not initialized unless its AvailableWaitHandle
+			// property is read, which we don't use.
+
+			// this.readSemaphore.Dispose();
+
 			IsDisposed = true;
 		}
 

--- a/src/cs/Ssh/SshStream.cs
+++ b/src/cs/Ssh/SshStream.cs
@@ -18,7 +18,10 @@ namespace Microsoft.DevTunnels.Ssh;
 /// </remarks>
 public class SshStream : Stream
 {
+#pragma warning disable CA2213 // Disposable fields should be disposed
 	private readonly SemaphoreSlim readSemaphore;
+#pragma warning restore CA2213 // Disposable fields should be disposed
+
 	private readonly ConcurrentQueue<Buffer> readQueue;
 	private Buffer readBuffer;
 	private int readBufferOffset;

--- a/src/cs/Ssh/TaskChain.cs
+++ b/src/cs/Ssh/TaskChain.cs
@@ -150,6 +150,13 @@ internal class TaskChain : IDisposable
 	public void Dispose()
 	{
 		isDisposed = true;
-		semaphore.Dispose();
+
+		// SemaphoreSlim.Dispose() is not thread-safe and may cause WaitAsync(CancellationToken) not being cancelled
+		// when SemaphoreSlim.Dispose is invoked immediately after CancellationTokenSource.Cancel.
+		// See https://github.com/dotnet/runtime/issues/59639
+		// SemaphoreSlim.Dispose() only disposes it's wait handle, which is not initialized unless its AvailableWaitHandle
+		// property is read, which we don't use.
+
+		// semaphore.Dispose();
 	}
 }

--- a/src/cs/Ssh/TaskChain.cs
+++ b/src/cs/Ssh/TaskChain.cs
@@ -10,7 +10,11 @@ namespace Microsoft.DevTunnels.Ssh;
 internal class TaskChain : IDisposable
 {
 	private Task? runInSequenceTask;
+
+#pragma warning disable CA2213 // Disposable fields should be disposed
 	private readonly SemaphoreSlim semaphore = new (1);
+#pragma warning restore CA2213 // Disposable fields should be disposed
+
 	private bool isDisposed;
 	private readonly TraceSource trace;
 


### PR DESCRIPTION
Fix for https://github.com/microsoft/basis-planning/issues/769

`SemaphoreSlim.Dispose()` is not thread-safe and may cause `WaitAsync(CancellationToken)` not being cancelled when `SemaphoreSlim.Dispose` is invoked immediately after `CancellationTokenSource.Cancel`. See https://github.com/dotnet/runtime/issues/59639

`SemaphoreSlim.Dispose()` only disposes it's wait handle, which is not initialized unless its `AvailableWaitHandle` property is read, and SSH library doesn't use it.

The fix is just to not dispose slim semaphores.

