### PR TITLE
Update symbol expiry to 3 years

### DIFF
--- a/.pipelines/dev-tunnels-ssh-ci.yaml
+++ b/.pipelines/dev-tunnels-ssh-ci.yaml
@@ -153,7 +153,7 @@ jobs:
           SearchPattern: '**\*.pdb'
           SymbolServerType: TeamServices
           # Expiration parameter: https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/azure-artifacts/symbol-service#how-to-change-the-expiration-date-of-a-symbol-request
-          SymbolExpirationInDays: '30'
+          SymbolExpirationInDays: '1095'
 
       - task: PublishBuildArtifacts@1
         displayName: Publish symbols to drop artifacts


### PR DESCRIPTION
Changes the default symbol expiration from 30 days to 3 years.