### PR TITLE
Fix task chaining for concurrent session requests

### DIFF
--- a/src/cs/Ssh/SshSession.cs
+++ b/src/cs/Ssh/SshSession.cs
@@ -1549,7 +1549,7 @@ public class SshSession : IDisposable
 					Trace.TraceEvent(
 						TraceEventType.Error,
 						SshTraceEventIds.SessionRequestFailed,
-						$"OnSessionRequest failed with exception ${ex.ToString()}.");
+						$"OnSessionRequest failed with exception ${ex}.");
 
 					// Send failure message in case of exception
 					result.SetResult(new SessionRequestFailureMessage());
@@ -1569,9 +1569,9 @@ public class SshSession : IDisposable
 					catch (Exception ex)
 					{
 						Trace.TraceEvent(
-									TraceEventType.Error,
-									SshTraceEventIds.SessionRequestFailed,
-									$"Session request response task failed with exception ${ex.ToString()}.");
+							TraceEventType.Error,
+							SshTraceEventIds.SessionRequestFailed,
+							$"Session request response task failed with exception ${ex}.");
 						result.SetResult(new SessionRequestFailureMessage());
 					}
 				}),
@@ -1607,7 +1607,7 @@ public class SshSession : IDisposable
 				Trace.TraceEvent(
 					TraceEventType.Error,
 					SshTraceEventIds.SessionRequestFailed,
-					$"OnSessionRequest send response failed with exception ${ex?.ToString()}.");
+					$"OnSessionRequest send response failed with exception ${ex}.");
 			},
 			cancellation).ConfigureAwait(false);
 	}

--- a/src/cs/Ssh/TaskChain.cs
+++ b/src/cs/Ssh/TaskChain.cs
@@ -64,7 +64,7 @@ internal class TaskChain : IDisposable
 
 			if (runInSequenceTask == null)
 			{
-				runInSequenceTask = Task.Factory.StartNew(
+				runInSequenceTask = Task.Run(
 					async () =>
 					{
 						try
@@ -77,14 +77,12 @@ internal class TaskChain : IDisposable
 							onError(ex);
 						}
 					},
-					cancellation,
-					TaskCreationOptions.None,
-					TaskScheduler.Default);
+					cancellation);
 			}
 			else
 			{
 				runInSequenceTask = runInSequenceTask.ContinueWith(
-					async _ =>
+					async (_) =>
 					{
 						try
 						{


### PR DESCRIPTION
A tunnel relay test was sometimes failing while forwarding multiple ports. I traced the failure to a problem with how `TaskFactory.StartNew()` was used for task chaining; the returned task does not wait for the inner task to complete, so continuation tasks may run concurrently with the first task. The added `OverlappingSessionRequests` test case reproduced the problem.