### PR TITLE
Make MultiChannelStream and SecureStream classes more extensible

### DIFF
--- a/src/ts/ssh/multiChannelStream.ts
+++ b/src/ts/ssh/multiChannelStream.ts
@@ -29,7 +29,7 @@ import { ChannelOpenMessage } from './messages/connectionMessages';
  * same transport stream, as long as the other side does the complementary action.
  */
 export class MultiChannelStream implements Disposable {
-	private readonly session: SshSession;
+	protected readonly session: SshSession;
 	private disposed: boolean = false;
 	private disposables: Disposable[] = [];
 
@@ -37,7 +37,7 @@ export class MultiChannelStream implements Disposable {
 	 * Creates a new multi-channel stream over an underlying transport stream.
 	 * @param transportStream Stream that is used to multiplex all the channels.
 	 */
-	public constructor(private readonly transportStream: Stream) {
+	public constructor(protected readonly transportStream: Stream) {
 		if (!transportStream) throw new TypeError('transportStream is required.');
 
 		const noSecurityConfig = new SshSessionConfiguration(false);

--- a/src/ts/ssh/secureStream.ts
+++ b/src/ts/ssh/secureStream.ts
@@ -32,13 +32,13 @@ import { PromiseCompletionSource } from './util/promiseCompletionSource';
  * before beginning to send and receive data.
  */
 export class SecureStream extends Duplex implements Disposable {
-	private readonly session: SshSession;
-	private readonly clientCredentials: SshClientCredentials | null = null;
-	private readonly serverCredentials: SshServerCredentials | null = null;
-	private readonly connectCompletion = new PromiseCompletionSource<SshStream>();
-	private stream?: SshStream;
+	protected readonly session: SshSession;
+	protected readonly clientCredentials: SshClientCredentials | null = null;
+	protected readonly serverCredentials: SshServerCredentials | null = null;
+	protected readonly connectCompletion = new PromiseCompletionSource<SshStream>();
+	protected stream?: SshStream;
 	private disposed: boolean = false;
-	private disposables: Disposable[] = [];
+	protected disposables: Disposable[] = [];
 
 	/**
 	 * Creates a new multi-channel stream over an underlying transport stream.


### PR DESCRIPTION
These changes enable the `MultiChannelStream` or `SecureStream` classes to be extended with new behaviors that use their wrapped SSH session.

- Change the private `transportStream` and `session` fields to protected properties.
- Make some selected C# methods in those classes `virtual`. (JS methods are always virtual.)
