### PR TITLE
changing ClientSSH logs as verbose

### DIFF
--- a/src/cs/Ssh.Tcp/Services/RemotePortForwarder.cs
+++ b/src/cs/Ssh.Tcp/Services/RemotePortForwarder.cs
@@ -144,7 +144,7 @@ public class RemotePortForwarder : RemotePortConnector
 		var traceMessage = $"{nameof(PortForwardingService)} forwarded channel " +
 			$"#{channel.ChannelId} connection to {localHost}:{localPort}.";
 		trace.TraceEvent(
-			TraceEventType.Information,
+			TraceEventType.Verbose,
 			SshTraceEventIds.PortForwardConnectionOpened,
 			traceMessage);
 		pfs.AddStreamForwarder(streamForwarder);

--- a/src/ts/ssh-tcp/services/streamForwarder.ts
+++ b/src/ts/ssh-tcp/services/streamForwarder.ts
@@ -38,7 +38,7 @@ export class StreamForwarder implements Disposable {
 			}
 
 			this.trace(
-				TraceLevel.Info,
+				TraceLevel.Verbose,
 				SshTraceEventIds.portForwardChannelClosed,
 				`Stream forwarder ${abort ? 'aborted' : 'closed'} connection.`,
 			);


### PR DESCRIPTION
Fixes #840

changing some SSH logs as verbose. So CLi user can have more clean output for non-verbose actions 