### PR TITLE
SecureStream reconnect and related diagnostics

### DIFF
--- a/src/cs/Ssh.Tcp/Events/ForwardedPortsCollection.cs
+++ b/src/cs/Ssh.Tcp/Events/ForwardedPortsCollection.cs
@@ -64,6 +64,9 @@ public class ForwardedPortsCollection : IReadOnlyCollection<ForwardedPort>
 	/// <summary>Event raised when a port is added to the collection.</summary>
 	public event EventHandler<ForwardedPortEventArgs>? PortAdded;
 
+	/// <summary>Event raised when a port in the collection is updated.</summary>
+	public event EventHandler<ForwardedPortEventArgs>? PortUpdated;
+
 	/// <summary>Event raised when a port is removed from the collection.</summary>
 	public event EventHandler<ForwardedPortEventArgs>? PortRemoved;
 
@@ -73,14 +76,16 @@ public class ForwardedPortsCollection : IReadOnlyCollection<ForwardedPort>
 	/// <summary>Event raised when a channel is removed from the collection.</summary>
 	public event EventHandler<ForwardedPortChannelEventArgs>? PortChannelRemoved;
 
-	internal void AddPort(ForwardedPort port)
+	internal void AddOrUpdatePort(ForwardedPort port)
 	{
-		if (!this.portChannelMap.TryAdd(port, new ConcurrentDictionary<uint, SshChannel>()))
+		if (this.portChannelMap.TryAdd(port, new ConcurrentDictionary<uint, SshChannel>()))
 		{
-			throw new InvalidOperationException($"Port {port} is already in the collection.");
+			PortAdded?.Invoke(this, new ForwardedPortEventArgs(port));
 		}
-
-		PortAdded?.Invoke(this, new ForwardedPortEventArgs(port));
+		else
+		{
+			PortUpdated?.Invoke(this, new ForwardedPortEventArgs(port));
+		}
 	}
 
 	internal void RemovePort(ForwardedPort port)

--- a/src/cs/Ssh.Tcp/Events/ForwardedPortsCollection.cs
+++ b/src/cs/Ssh.Tcp/Events/ForwardedPortsCollection.cs
@@ -64,7 +64,11 @@ public class ForwardedPortsCollection : IReadOnlyCollection<ForwardedPort>
 	/// <summary>Event raised when a port is added to the collection.</summary>
 	public event EventHandler<ForwardedPortEventArgs>? PortAdded;
 
-	/// <summary>Event raised when a port in the collection is updated.</summary>
+	/// <summary>
+	/// Event raised when a port in the collection is updated. "Updating" a port doesn't
+	/// change anything at the SSH protocol level, but the application may use this event
+	/// as a signal to update or refresh its state for the forwarded port.
+	/// </summary>
 	public event EventHandler<ForwardedPortEventArgs>? PortUpdated;
 
 	/// <summary>Event raised when a port is removed from the collection.</summary>

--- a/src/cs/Ssh.Tcp/Services/RemotePortForwarder.cs
+++ b/src/cs/Ssh.Tcp/Services/RemotePortForwarder.cs
@@ -69,7 +69,7 @@ public class RemotePortForwarder : RemotePortConnector
 		var channel = request.Channel;
 
 		// The ChannelForwarder takes ownership of the TcpClient; it will be disposed
-		// when the PortForwardingService is diposed. And the channel will be disposed when the
+		// when the PortForwardingService is disposed. And the channel will be disposed when the
 		// connection ends, so the SshStream does not need to be disposed separately.
 #pragma warning disable CA2000 // Dispose objects before losing scope
 		var tcpClient = new TcpClient();
@@ -125,8 +125,8 @@ public class RemotePortForwarder : RemotePortConnector
 		StreamForwarder streamForwarder;
 		try
 		{
-			// The PortForwardingService takes ownership of the ChannelForwarder; it will be disposed
-			// when the PortForwardingService is diposed.
+			// The PortForwardingService takes ownership of the StreamForwarder; it will be disposed
+			// when the PortForwardingService is disposed.
 #pragma warning disable CA2000 // Dispose objects before losing scope
 			streamForwarder = new StreamForwarder(
 				tcpClient.GetStream(), forwardedStream, channel.Trace);

--- a/src/cs/Ssh/Services/ConnectionService.cs
+++ b/src/cs/Ssh/Services/ConnectionService.cs
@@ -299,7 +299,7 @@ internal class ConnectionService : SshService
 			return;
 		}
 
-		// Save a copy of the message because its buffer will be overwitten by the next receive.
+		// Save a copy of the message because its buffer will be overwritten by the next receive.
 		message = message.ConvertTo<ChannelOpenMessage>(copy: true);
 
 		// The confirmation message may be reassigned if the opening task returns a custom message.
@@ -511,7 +511,7 @@ internal class ConnectionService : SshService
 					"Channel confirmation was not requested.", SshDisconnectReason.ProtocolError);
 			}
 
-			// Save a copy of the message because its buffer will be overwitten by the next receive.
+			// Save a copy of the message because its buffer will be overwritten by the next receive.
 			message = message.ConvertTo<ChannelOpenConfirmationMessage>(copy: true);
 
 			channel = new SshChannel(
@@ -616,7 +616,7 @@ internal class ConnectionService : SshService
 			Trace.TraceEvent(
 				TraceEventType.Warning,
 				SshTraceEventIds.ChannelRequestFailed,
-				$"Invalid channel ID {channelMessage.RecipientChannel} in {messageString}");
+				$"{Session}: Invalid channel ID {channelMessage.RecipientChannel} in {messageString}");
 		}
 
 		return channel;

--- a/src/cs/Ssh/SshChannel.cs
+++ b/src/cs/Ssh/SshChannel.cs
@@ -428,7 +428,7 @@ public class SshChannel : IDisposable
 					Trace.TraceEvent(
 						TraceEventType.Error,
 						SshTraceEventIds.ChannelRequestFailed,
-						$"Channel request failed with exception {ex.ToString()}.");
+						$"Channel request failed with exception {ex}.");
 
 					// Send a failure response on exception
 					args.ResponseTask = null;
@@ -452,7 +452,7 @@ public class SshChannel : IDisposable
 					Trace.TraceEvent(
 						 TraceEventType.Error,
 						 SshTraceEventIds.ChannelRequestFailed,
-						 $"Channel request response task failed with exception {ex.ToString()}.");
+						 $"Channel request response task failed with exception {ex}.");
 					response = new ChannelFailureMessage();
 					sshRequestArgs.IsAuthorized = false;
 				}
@@ -492,7 +492,7 @@ public class SshChannel : IDisposable
 				Trace.TraceEvent(
 					TraceEventType.Error,
 					SshTraceEventIds.ChannelRequestFailed,
-					$"Channel request run in sequence failed with exception {ex?.ToString()}.");
+					$"Channel request run in sequence failed with exception {ex}.");
 			},
 			() => requestTask(serviceType, serviceConfig),
 			cancellation).ConfigureAwait(false);

--- a/src/cs/Ssh/SshChannel.cs
+++ b/src/cs/Ssh/SshChannel.cs
@@ -428,7 +428,7 @@ public class SshChannel : IDisposable
 					Trace.TraceEvent(
 						TraceEventType.Error,
 						SshTraceEventIds.ChannelRequestFailed,
-						$"Channel request failed with exception ${ex.ToString()}.");
+						$"Channel request failed with exception {ex.ToString()}.");
 
 					// Send a failure response on exception
 					args.ResponseTask = null;
@@ -452,7 +452,7 @@ public class SshChannel : IDisposable
 					Trace.TraceEvent(
 						 TraceEventType.Error,
 						 SshTraceEventIds.ChannelRequestFailed,
-						 $"Channel request response task failed with exception ${ex.ToString()}.");
+						 $"Channel request response task failed with exception {ex.ToString()}.");
 					response = new ChannelFailureMessage();
 					sshRequestArgs.IsAuthorized = false;
 				}
@@ -492,7 +492,7 @@ public class SshChannel : IDisposable
 				Trace.TraceEvent(
 					TraceEventType.Error,
 					SshTraceEventIds.ChannelRequestFailed,
-					$"Channel request run in sequence failed with exception ${ex?.ToString()}.");
+					$"Channel request run in sequence failed with exception {ex?.ToString()}.");
 			},
 			() => requestTask(serviceType, serviceConfig),
 			cancellation).ConfigureAwait(false);
@@ -735,17 +735,17 @@ public class SshChannel : IDisposable
 
 		if (this.exitStatus.HasValue)
 		{
-			closedMessage = $"{this} closed {originMessage}: status={this.exitStatus}.";
+			closedMessage = $"{Session} {this} closed {originMessage}: status={this.exitStatus}.";
 			args = new SshChannelClosedEventArgs(this.exitStatus.Value);
 		}
 		else if (!string.IsNullOrEmpty(this.exitSignal))
 		{
-			closedMessage = $"{this} closed {originMessage}: signal={this.exitSignal} {this.exitErrorMessage}.";
+			closedMessage = $"{Session} {this} closed {originMessage}: signal={this.exitSignal} {this.exitErrorMessage}.";
 			args = new SshChannelClosedEventArgs(this.exitSignal!, this.exitErrorMessage);
 		}
 		else
 		{
-			closedMessage = $"{this} closed {originMessage}.";
+			closedMessage = $"{Session} {this} closed {originMessage}.";
 			args = SshChannelClosedEventArgs.Empty;
 		}
 

--- a/src/cs/Ssh/SshServerSession.cs
+++ b/src/cs/Ssh/SshServerSession.cs
@@ -308,7 +308,7 @@ public class SshServerSession : SshSession
 		Trace.TraceEvent(
 			TraceEventType.Information,
 			SshTraceEventIds.ServerSessionReconnecting,
-			$"{reconnectSession} reconnected. Re-sent {messagesToResend.Count} dropped messages.");
+			$"{this} reconnected {reconnectSession}. Re-sent {messagesToResend.Count} dropped messages.");
 
 		// Notify event listeners about the successful reconnection.
 		reconnectSession.Reconnected?.Invoke(reconnectSession, EventArgs.Empty);

--- a/src/cs/Ssh/SshSession.cs
+++ b/src/cs/Ssh/SshSession.cs
@@ -628,7 +628,9 @@ public class SshSession : IDisposable
 			Protocol?.Disconnect();
 
 			this.Trace.TraceEvent(
-				TraceEventType.Information, SshTraceEventIds.SessionDisconnected, "Disconnected.");
+				TraceEventType.Information,
+				SshTraceEventIds.SessionDisconnected,
+				$"{this} Disconnected.");
 			this.Disconnected?.Invoke(this, EventArgs.Empty);
 			return;
 		}
@@ -1549,7 +1551,7 @@ public class SshSession : IDisposable
 					Trace.TraceEvent(
 						TraceEventType.Error,
 						SshTraceEventIds.SessionRequestFailed,
-						$"OnSessionRequest failed with exception ${ex}.");
+						$"OnSessionRequest failed with exception {ex}.");
 
 					// Send failure message in case of exception
 					result.SetResult(new SessionRequestFailureMessage());
@@ -1571,7 +1573,7 @@ public class SshSession : IDisposable
 						Trace.TraceEvent(
 							TraceEventType.Error,
 							SshTraceEventIds.SessionRequestFailed,
-							$"Session request response task failed with exception ${ex}.");
+							$"Session request response task failed with exception {ex}.");
 						result.SetResult(new SessionRequestFailureMessage());
 					}
 				}),
@@ -1607,7 +1609,7 @@ public class SshSession : IDisposable
 				Trace.TraceEvent(
 					TraceEventType.Error,
 					SshTraceEventIds.SessionRequestFailed,
-					$"OnSessionRequest send response failed with exception ${ex}.");
+					$"OnSessionRequest send response failed with exception {ex}.");
 			},
 			cancellation).ConfigureAwait(false);
 	}
@@ -1708,7 +1710,9 @@ public class SshSession : IDisposable
 		var verifier = Algorithms?.Verifier;
 		if (verifier == null)
 		{
-			return false;
+			throw new InvalidOperationException(
+				"HMAC algorithm not available when verifying reconnection. " +
+				"The connection may have been lost before the initial key-exchange completed.");
 		}
 
 		var result = verifier.Verify(writer.ToBuffer(), reconnectToken);

--- a/src/cs/Ssh/TaskChain.cs
+++ b/src/cs/Ssh/TaskChain.cs
@@ -53,11 +53,11 @@ internal class TaskChain : IDisposable
 		try
 		{
 			await semaphore.WaitAsync(cancellation).ConfigureAwait(false);
-			
-			if (runInSequenceTask != null && 
+
+			if (runInSequenceTask != null &&
 				(runInSequenceTask.IsCanceled || runInSequenceTask.Exception != null))
 			{
-				// If one task in the sequence is cancelled we have to reset runInSequenceTask 
+				// If one task in the sequence is cancelled we have to reset runInSequenceTask
 				// so that all subsequent queueing will succeed.
 				runInSequenceTask = null;
 			}
@@ -142,7 +142,7 @@ internal class TaskChain : IDisposable
 					trace.TraceEvent(
 						TraceEventType.Error,
 						SshTraceEventIds.TaskChainError,
-						$"Waiting for task chain failed with exception {ex?.ToString()}.");
+						$"Waiting for task chain failed with exception {ex}.");
 				},
 				cancellationToken).ConfigureAwait(false);
 			await semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);

--- a/src/cs/Ssh/TaskChain.cs
+++ b/src/cs/Ssh/TaskChain.cs
@@ -142,7 +142,7 @@ internal class TaskChain : IDisposable
 					trace.TraceEvent(
 						TraceEventType.Error,
 						SshTraceEventIds.TaskChainError,
-						$"Waiting for task chain failed with exception ${ex?.ToString()}.");
+						$"Waiting for task chain failed with exception {ex?.ToString()}.");
 				},
 				cancellationToken).ConfigureAwait(false);
 			await semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);

--- a/src/ts/ssh-tcp/events/forwardedPortsCollection.ts
+++ b/src/ts/ssh-tcp/events/forwardedPortsCollection.ts
@@ -87,18 +87,32 @@ export class ForwardedPortsCollection implements ReadonlySet<ForwardedPort> {
 	}
 
 	private readonly portAddedEmitter = new Emitter<ForwardedPortEventArgs>();
+
+	/** Event raised when a port is added to the collection. */
 	public readonly onPortAdded = this.portAddedEmitter.event;
 
 	private readonly portUpdatedEmitter = new Emitter<ForwardedPortEventArgs>();
+
+	/**
+	 * Event raised when a port in the collection is updated. "Updating" a port doesn't
+	 * change anything at the SSH protocol level, but the application may use this event
+	 * as a signal to update or refresh its state for the forwarded port.
+	 */
 	public readonly onPortUpdated = this.portUpdatedEmitter.event;
 
 	private readonly portRemovedEmitter = new Emitter<ForwardedPortEventArgs>();
+
+	/** Event raised when a port is removed from the collection. */
 	public readonly onPortRemoved = this.portRemovedEmitter.event;
 
 	private readonly portChannelAddedEmitter = new Emitter<ForwardedPortChannelEventArgs>();
+
+	/** Event raised when a channel is added to the collection. */
 	public readonly onPortChannelAdded = this.portChannelAddedEmitter.event;
 
 	private readonly portChannelRemovedEmitter = new Emitter<ForwardedPortChannelEventArgs>();
+
+	/** Event raised when a channel is removed from the collection. */
 	public readonly onPortChannelRemoved = this.portChannelRemovedEmitter.event;
 
 	/** Finds the first port in the collection that matches a predicate. */

--- a/src/ts/ssh-tcp/events/forwardedPortsCollection.ts
+++ b/src/ts/ssh-tcp/events/forwardedPortsCollection.ts
@@ -89,6 +89,9 @@ export class ForwardedPortsCollection implements ReadonlySet<ForwardedPort> {
 	private readonly portAddedEmitter = new Emitter<ForwardedPortEventArgs>();
 	public readonly onPortAdded = this.portAddedEmitter.event;
 
+	private readonly portUpdatedEmitter = new Emitter<ForwardedPortEventArgs>();
+	public readonly onPortUpdated = this.portUpdatedEmitter.event;
+
 	private readonly portRemovedEmitter = new Emitter<ForwardedPortEventArgs>();
 	public readonly onPortRemoved = this.portRemovedEmitter.event;
 
@@ -110,9 +113,9 @@ export class ForwardedPortsCollection implements ReadonlySet<ForwardedPort> {
 	}
 
 	/* @internal */
-	public addPort(port: ForwardedPort): void {
+	public addOrUpdatePort(port: ForwardedPort): void {
 		if (this.has(port)) {
-			throw new Error(`Port ${port} is already in the collection.`);
+			this.portUpdatedEmitter.fire(new ForwardedPortEventArgs(port));
 		}
 
 		this.portChannelMap.set(port.toString(), [port, []]);

--- a/src/ts/ssh/secureStream.ts
+++ b/src/ts/ssh/secureStream.ts
@@ -61,9 +61,12 @@ export class SecureStream extends Duplex implements Disposable {
 				cb: (error?: Error | null) => void,
 			): void {
 				this.connectCompletion.promise.then((stream) => {
-					if (!stream) throw new ObjectDisposedError('SecureStream');
-					// eslint-disable-next-line no-underscore-dangle
-					stream._write(chunk, encoding, cb);
+					if (!stream) {
+						cb(new ObjectDisposedError('SecureStream'));
+					} else {
+						// eslint-disable-next-line no-underscore-dangle
+						stream._write(chunk, encoding, cb);
+					}
 				}, cb);
 			},
 			writev(
@@ -72,16 +75,22 @@ export class SecureStream extends Duplex implements Disposable {
 				cb: (error?: Error | null) => void,
 			): void {
 				this.connectCompletion.promise.then((stream) => {
-					if (!stream) throw new ObjectDisposedError('SecureStream');
-					// eslint-disable-next-line no-underscore-dangle
-					stream._writev!(chunks, cb);
+					if (!stream) {
+						cb(new ObjectDisposedError('SecureStream'));
+					} else {
+						// eslint-disable-next-line no-underscore-dangle
+						stream._writev!(chunks, cb);
+					}
 				}, cb);
 			},
 			final(this: SecureStream, cb: (err?: Error | null) => void): void {
 				this.connectCompletion.promise.then((stream) => {
-					if (!stream) throw new ObjectDisposedError('SecureStream');
-					// eslint-disable-next-line no-underscore-dangle
-					stream._final(cb);
+					if (!stream) {
+						cb(new ObjectDisposedError('SecureStream'));
+					} else {
+						// eslint-disable-next-line no-underscore-dangle
+						stream._final(cb);
+					}
 				}, cb);
 			},
 			read(this: SecureStream, size: number): void {

--- a/src/ts/ssh/services/connectionService.ts
+++ b/src/ts/ssh/services/connectionService.ts
@@ -471,7 +471,7 @@ export class ConnectionService extends SshService {
 			this.trace(
 				TraceLevel.Warning,
 				SshTraceEventIds.channelRequestFailed,
-				`Invalid channel ID ${channelMessage.recipientChannel} in {messageString}.`,
+				`Invalid channel ID ${channelMessage.recipientChannel} in ${messageString}.`,
 			);
 		}
 		return channel;

--- a/src/ts/ssh/services/connectionService.ts
+++ b/src/ts/ssh/services/connectionService.ts
@@ -23,7 +23,7 @@ import { CancellationToken, Disposable } from 'vscode-jsonrpc';
 import { PromiseCompletionSource } from '../util/promiseCompletionSource';
 import { SshChannel } from '../sshChannel';
 import { CancellationError } from '../util/cancellation';
-import { SshChannelError, SshConnectionError } from '../errors';
+import { ObjectDisposedError, SshChannelError, SshConnectionError } from '../errors';
 import { SshChannelOpeningEventArgs } from '../events/sshChannelOpeningEventArgs';
 import { serviceActivation } from './serviceActivation';
 import { TraceLevel, SshTraceEventIds } from '../trace';
@@ -88,7 +88,7 @@ export class ConnectionService extends SshService {
 		}
 
 		for (const channelCompletion of channelCompletions) {
-			channelCompletion.reject(new SshConnectionError('Session closed.'));
+			channelCompletion.reject(new ObjectDisposedError('Session closed.'));
 		}
 
 		super.dispose();

--- a/test/cs/Ssh.Test/MockNetworkStream.cs
+++ b/test/cs/Ssh.Test/MockNetworkStream.cs
@@ -80,8 +80,8 @@ class MockNetworkStream : Stream
 
 		// Retry the read when getting a zero-length result.
 		// This accounts for a bug in the pipe stream pair used for unit-testing.
-		// These streams return a zero-lengh result when there is no available data,
-		// whereas a network stream would not return a zero-length result until graefully closed.
+		// These streams return a zero-length result when there is no available data,
+		// whereas a network stream would not return a zero-length result until gracefully closed.
 		int result = 0;
 		for (int i = 0; result == 0 && i < 2; i++)
 		{

--- a/test/ts/ssh-test/reconnectTests.ts
+++ b/test/ts/ssh-test/reconnectTests.ts
@@ -19,6 +19,7 @@ import {
 	SshConnectionError,
 	SshReconnectError,
 	SshReconnectFailureReason,
+	ObjectDisposedError,
 } from '@microsoft/dev-tunnels-ssh';
 
 import { DuplexStream } from './duplexStream';
@@ -591,7 +592,7 @@ export class ReconnectTests {
 		const acceptChannelPromise = assert.rejects(async () => {
 			await newServerSession.connect(serverStream);
 			await newServerSession.acceptChannel();
-		}, SshConnectionError);
+		}, ObjectDisposedError);
 
 		await Promise.all([reconnectPromise, acceptChannelPromise]);
 		await reconnectPromise;


### PR DESCRIPTION
 - Add reconnection APIs to the `SecureStream` class.
 - Add `PortUpdated` event to PFS forwarded ports collection. This makes it possible to "refresh" forwarded ports status after a reconnection, and reconnect `SecureStream` channels that run over forwarded ports.
 - Improve various diagnostic messages related to reconnection.
