### PR TITLE
Fix reconnect timing bug

### DIFF
--- a/src/cs/Ssh/MultiChannelStream.cs
+++ b/src/cs/Ssh/MultiChannelStream.cs
@@ -321,7 +321,8 @@ public class MultiChannelStream : IDisposable
 	/// </summary>
 	public virtual async Task CloseAsync()
 	{
-		await this.Session.CloseAsync(SshDisconnectReason.None, this.Session.GetType().Name + " disposed").ConfigureAwait(false);
+		await this.Session.CloseAsync(
+			SshDisconnectReason.None, this.Session.GetType().Name + " disposed.").ConfigureAwait(false);
 		this.Session.Dispose();
 
 #if !NETSTANDARD2_0 && !NET4

--- a/src/cs/Ssh/SecureStream.cs
+++ b/src/cs/Ssh/SecureStream.cs
@@ -305,7 +305,7 @@ public class SecureStream : Stream
 	{
 		// Disposing the session closes the channel, which causes this SecureStream to be disposed.
 		await this.Session.CloseAsync(
-			SshDisconnectReason.None, this.Session.GetType().Name + " disposed").ConfigureAwait(false);
+			SshDisconnectReason.None, this.Session.GetType().Name + " disposed.").ConfigureAwait(false);
 		this.Session.Dispose();
 
 #if !NETSTANDARD2_0 && !NET4

--- a/src/cs/Ssh/Services/KeyExchangeService.cs
+++ b/src/cs/Ssh/Services/KeyExchangeService.cs
@@ -275,6 +275,13 @@ internal class KeyExchangeService : SshService
 					await Session.SendMessageAsync(reply, cancellation).ConfigureAwait(false);
 				}
 			}
+			else
+			{
+				Trace.TraceEvent(
+					TraceEventType.Verbose,
+					SshTraceEventIds.AlgorithmNegotiation,
+					"Already sent correct guess for key-exchange init.");
+			}
 
 			this.exchangeContext.IsExtensionInfoRequested = this.isInitialExchange &&
 				message.KeyExchangeAlgorithms?.Contains(ServerExtensionInfoSignal) == true;

--- a/src/cs/Ssh/Services/KeyExchangeService.cs
+++ b/src/cs/Ssh/Services/KeyExchangeService.cs
@@ -73,13 +73,15 @@ internal class KeyExchangeService : SshService
 				"Key exchange not started.", SshDisconnectReason.ProtocolError);
 		}
 
-		if (this.exchangeContext.NewAlgorithms == null)
+		SshSessionAlgorithms? newAlgorithms = this.exchangeContext.NewAlgorithms;
+		if (newAlgorithms == null)
 		{
 			throw new SshConnectionException(
 				"Key exchange not completed.", SshDisconnectReason.ProtocolError);
 		}
 
-		SshSessionAlgorithms newAlgorithms = this.exchangeContext.NewAlgorithms;
+		newAlgorithms.IsExtensionInfoRequested = this.exchangeContext.IsExtensionInfoRequested;
+
 		this.exchangeContext = null;
 		return newAlgorithms;
 	}
@@ -208,6 +210,7 @@ internal class KeyExchangeService : SshService
 			this.exchangeContext.NewAlgorithms = new SshSessionAlgorithms();
 			await Session.HandleMessageAsync(new NewKeysMessage(), cancellation)
 				.ConfigureAwait(false);
+			return;
 		}
 		else
 		{
@@ -241,78 +244,64 @@ internal class KeyExchangeService : SshService
 				message.CompressionAlgorithmsServerToClient);
 		}
 
-		string extensionInfoSignal;
 		if (Session is SshClientSession)
 		{
-			if (this.exchangeContext != null)
+			this.exchangeContext.ServerKexInitPayload = message.ToBuffer().ToArray();
+
+			// If the exchange value is already initialized then this side sent a guess.
+			bool alreadySentGuess = this.exchangeContext.ExchangeValue != null;
+
+			// Check if the negotiated algorithm is the one preferred by THIS side.
+			// This means if there was a "guess" at kex initialization then it was correct.
+			bool negotiatedKexAlgorithmIsPreferred =
+				this.exchangeContext.KeyExchange ==
+				Session.Config.AvailableKeyExchangeAlgorithms.FirstOrDefault();
+
+			// If a guess was not sent, or the guess was wrong, send the init message now.
+			if (!alreadySentGuess || !negotiatedKexAlgorithmIsPreferred)
 			{
-				this.exchangeContext.ServerKexInitPayload = message.ToBuffer().ToArray();
-
-				// If the exchange value is already initialized then this side sent a guess.
-				bool alreadySentGuess = this.exchangeContext.ExchangeValue != null;
-
-				// Check if the negotiated algorithm is the one preferred by THIS side.
-				// This means if there was a "guess" at kex initialization then it was correct.
-				bool negotiatedKexAlgorthmIsPreferred =
-					this.exchangeContext.KeyExchange ==
-					Session.Config.AvailableKeyExchangeAlgorithms.FirstOrDefault();
-
-				// If a guess was not sent, or the guess was wrong, send the init message now.
-				if (!alreadySentGuess || !negotiatedKexAlgorthmIsPreferred)
+				var kexAlgorithm = Session.Config.GetKeyExchangeAlgorithm(
+					this.exchangeContext!.KeyExchange);
+				if (kexAlgorithm != null)
 				{
-					var kexAlgorithm = Session.Config.GetKeyExchangeAlgorithm(
-						this.exchangeContext!.KeyExchange);
-					if (kexAlgorithm != null)
-					{
-						this.exchangeContext.Exchange = kexAlgorithm!.CreateKeyExchange();
-						this.exchangeContext.ExchangeValue =
-							this.exchangeContext.Exchange.StartKeyExchange().ToArray();
+					this.exchangeContext.Exchange = kexAlgorithm!.CreateKeyExchange();
+					this.exchangeContext.ExchangeValue =
+						this.exchangeContext.Exchange.StartKeyExchange().ToArray();
 
-						var reply = new KeyExchangeDhInitMessage
-						{
-							E = this.exchangeContext.ExchangeValue,
-						};
-						await Session.SendMessageAsync(reply, cancellation).ConfigureAwait(false);
-					}
+					var reply = new KeyExchangeDhInitMessage
+					{
+						E = this.exchangeContext.ExchangeValue,
+					};
+					await Session.SendMessageAsync(reply, cancellation).ConfigureAwait(false);
 				}
 			}
 
-			extensionInfoSignal = ServerExtensionInfoSignal;
+			this.exchangeContext.IsExtensionInfoRequested = this.isInitialExchange &&
+				message.KeyExchangeAlgorithms?.Contains(ServerExtensionInfoSignal) == true;
 		}
 		else
 		{
-			if (this.exchangeContext != null)
+			if (message.FirstKexPacketFollows)
 			{
-				if (message.FirstKexPacketFollows)
-				{
-					// The remote side indicated it is sending a guess immediately following.
-					// Check if the negotiated algorithm is the one preferred by the OTHER side.
-					// If so, the following "guess" will be correct. Otherwise it must be ignored.
-					bool negotiatedKexAlgorthmIsPreferred =
-						this.exchangeContext.KeyExchange ==
-						message.KeyExchangeAlgorithms?.FirstOrDefault();
-					var guessResult = (negotiatedKexAlgorthmIsPreferred ? "correct" : "incorrect");
-					var traceMessage = $"Client's {nameof(ExchangeContext.KeyExchange)} guess " +
-						$"({this.exchangeContext.KeyExchange}) was {guessResult}.";
-					Session.Trace.TraceEvent(
-						TraceEventType.Verbose,
-						SshTraceEventIds.AlgorithmNegotiation,
-						traceMessage);
-					this.exchangeContext.DiscardGuessedInit = !negotiatedKexAlgorthmIsPreferred;
-				}
-
-				this.exchangeContext.ClientKexInitPayload = message.ToBuffer().ToArray();
+				// The remote side indicated it is sending a guess immediately following.
+				// Check if the negotiated algorithm is the one preferred by the OTHER side.
+				// If so, the following "guess" will be correct. Otherwise it must be ignored.
+				bool negotiatedKexAlgorithmIsPreferred =
+					this.exchangeContext.KeyExchange ==
+					message.KeyExchangeAlgorithms?.FirstOrDefault();
+				var guessResult = (negotiatedKexAlgorithmIsPreferred ? "correct" : "incorrect");
+				var traceMessage = $"Client's {nameof(ExchangeContext.KeyExchange)} guess " +
+					$"({this.exchangeContext.KeyExchange}) was {guessResult}.";
+				Session.Trace.TraceEvent(
+					TraceEventType.Verbose,
+					SshTraceEventIds.AlgorithmNegotiation,
+					traceMessage);
+				this.exchangeContext.DiscardGuessedInit = !negotiatedKexAlgorithmIsPreferred;
 			}
 
-			extensionInfoSignal = ClientExtensionInfoSignal;
-		}
-
-		if (this.isInitialExchange &&
-			message.KeyExchangeAlgorithms?.Contains(extensionInfoSignal) == true)
-		{
-			// The extension info message will be blocked in the queue
-			// until immediately after the key-exchange is done.
-			await Session.SendExtensionInfoAsync(cancellation).ConfigureAwait(false);
+			this.exchangeContext.ClientKexInitPayload = message.ToBuffer().ToArray();
+			this.exchangeContext.IsExtensionInfoRequested = this.isInitialExchange &&
+				message.KeyExchangeAlgorithms?.Contains(ClientExtensionInfoSignal) == true;
 		}
 	}
 
@@ -737,5 +726,7 @@ internal class KeyExchangeService : SshService
 		public IKeyExchange? Exchange { get; set; }
 
 		public SshSessionAlgorithms? NewAlgorithms { get; set; }
+
+		public bool IsExtensionInfoRequested { get; set; }
 	}
 }

--- a/src/cs/Ssh/SshClientSession.cs
+++ b/src/cs/Ssh/SshClientSession.cs
@@ -498,9 +498,11 @@ public class SshClientSession : SshSession
 		int count = 0;
 		foreach (var message in messagesToResend)
 		{
-			await SendMessageAsync(message, cancellation).ConfigureAwait(false);
+			await Protocol!.SendMessageAsync(message, cancellation).ConfigureAwait(false);
 			count++;
 		}
+
+		await ContinueSendBlockedMessagesAfterReconnectAsync(cancellation).ConfigureAwait(false);
 
 		// Now the session is fully reconnected!
 		previousProtocolInstance.Dispose();

--- a/src/cs/Ssh/SshServerSession.cs
+++ b/src/cs/Ssh/SshServerSession.cs
@@ -188,7 +188,7 @@ public class SshServerSession : SshSession
 		if (this.reconnectableSessions == null)
 		{
 			throw new InvalidOperationException("Disconnected sessions collection " +
-				"should have been initialied when reconnect is enabled.");
+				"should have been initialized when reconnect is enabled.");
 		}
 
 		// Try to find the requested server session in the list of available disconnected
@@ -284,11 +284,12 @@ public class SshServerSession : SshSession
 			// Re-send the lost messages that the client requested.
 			foreach (var message in messagesToResend)
 			{
-				await reconnectSession.SendMessageAsync(message, cancellation).ConfigureAwait(false);
+				await reconnectSession.Protocol.SendMessageAsync(message, cancellation)
+					.ConfigureAwait(false);
 			}
 
 			// Now this server session is invalid because the client reconnected to another one.
-			Dispose();
+			Dispose(new SshConnectionException("Reconnected.", SshDisconnectReason.None));
 		}
 		finally
 		{

--- a/src/cs/Ssh/SshSession.cs
+++ b/src/cs/Ssh/SshSession.cs
@@ -815,7 +815,7 @@ public class SshSession : IDisposable
 			await CloseAsync(ex.DisconnectReason, ex).ConfigureAwait(false);
 
 			if (ex.DisconnectReason == SshDisconnectReason.ConnectionLost &&
-				ProtocolExtensions?.ContainsKey(SshProtocolExtensionNames.SessionReconnect) == true)
+				protocol.Extensions?.ContainsKey(SshProtocolExtensionNames.SessionReconnect) == true)
 			{
 				// Connection-lost exception when reconnect is enabled. Don't throw an exception;
 				// the message will remain in the reconnect message cache and will be re-sent
@@ -841,8 +841,7 @@ public class SshSession : IDisposable
 		{
 			// Sending failed due to a closed stream, but don't throw when reconnect is enabled.
 			// In that case the sent message is buffered and will be re-sent after reconnecting.
-			if (ProtocolExtensions?.ContainsKey(
-				SshProtocolExtensionNames.SessionReconnect) != true)
+			if (protocol.Extensions?.ContainsKey(SshProtocolExtensionNames.SessionReconnect) != true)
 			{
 				throw new SshConnectionException(
 					"Session is disconnected.",

--- a/src/cs/Ssh/SshSession.cs
+++ b/src/cs/Ssh/SshSession.cs
@@ -690,10 +690,16 @@ public class SshSession : IDisposable
 		GC.SuppressFinalize(this);
 	}
 
+	internal void Dispose(Exception ex)
+	{
+		this.closedException = ex;
+		Dispose();
+	}
+
 	protected virtual void Dispose(bool disposing)
 	{
 		var closedEx = this.closedException as SshConnectionException ??
-			new SshConnectionException("Session disposed.", this.closedException);
+			new SshConnectionException($"{GetType().Name} disposed.", this.closedException);
 
 		if (disposing)
 		{
@@ -716,7 +722,7 @@ public class SshSession : IDisposable
 						SshTraceEventIds.SessionClosing,
 						$"{this} Close()");
 					Closed?.Invoke(this, new SshSessionClosedEventArgs(
-						closedEx.DisconnectReason, GetType().Name + " disposed", closedEx));
+						closedEx.DisconnectReason, closedEx.Message, closedEx));
 				}
 			}
 
@@ -777,21 +783,26 @@ public class SshSession : IDisposable
 		var protocol = Protocol;
 		if (protocol == null) throw new InvalidOperationException("Not connected.");
 
-		// Delay sending messages if in the middle of a key (re-)exchange.
-		if (this.kexService?.Exchanging == true &&
-			message.MessageType > 4 &&
-			(message.MessageType < 20 || message.MessageType > 49))
-		{
-			this.blockedMessages.Enqueue(message);
-			return;
-		}
-
 		// Wait for blocked messages to clear before sending.
 		await this.blockedMessagesSemaphore.WaitAsync(cancellation).ConfigureAwait(false);
 
 		bool result;
 		try
 		{
+			// Defer sending messages if in the middle of a key (re-)exchange or reconnecting.
+			// But do not defer messages that are part of the key exchange or reconnect protocol.
+			if ((this.kexService?.Exchanging == true || Reconnecting) &&
+				message.MessageType > 4 &&
+				(message.MessageType < 20 || message.MessageType > 49) &&
+				!(Reconnecting &&
+					(message is SessionReconnectRequestMessage ||
+					message is SessionReconnectResponseMessage)))
+			{
+				this.blockedMessages.Enqueue(message);
+				this.blockedMessagesSemaphore.TryRelease();
+				return;
+			}
+
 			result = await protocol.SendMessageAsync(message, cancellation).ConfigureAwait(false);
 			this.blockedMessagesSemaphore.TryRelease();
 		}
@@ -842,7 +853,7 @@ public class SshSession : IDisposable
 
 	private async Task ContinueSendBlockedMessagesAsync(CancellationToken cancellation)
 	{
-		if (!this.blockedMessages.IsEmpty)
+		try
 		{
 			SshMessage message;
 			while (this.blockedMessages.TryDequeue(out message!))
@@ -850,9 +861,30 @@ public class SshSession : IDisposable
 				var protocol = Protocol;
 				if (protocol == null) throw new ObjectDisposedException(nameof(SshSession));
 
-				await protocol.SendMessageAsync(message, cancellation)
-					.ConfigureAwait(false);
+				await protocol.SendMessageAsync(message, cancellation).ConfigureAwait(false);
 			}
+		}
+		catch (Exception ex)
+		{
+			Trace.TraceEvent(
+				TraceEventType.Error, SshTraceEventIds.SendMessageFailed, ex.ToString());
+			await CloseAsync(SshDisconnectReason.ProtocolError, ex).ConfigureAwait(false);
+		}
+	}
+
+	internal async Task ContinueSendBlockedMessagesAfterReconnectAsync(
+		CancellationToken cancellation)
+	{
+		await this.blockedMessagesSemaphore.WaitAsync(cancellation).ConfigureAwait(false);
+		try
+		{
+			await ContinueSendBlockedMessagesAsync(cancellation).ConfigureAwait(false);
+
+			Reconnecting = false;
+		}
+		finally
+		{
+			this.blockedMessagesSemaphore.TryRelease();
 		}
 	}
 
@@ -860,7 +892,7 @@ public class SshSession : IDisposable
 	{
 		if (message == null) throw new ArgumentNullException(nameof(message));
 
-		// Dont wait for too long trying to send the disconnect message.
+		// Don't wait for too long trying to send the disconnect message.
 		var timeout = TimeSpan.FromMilliseconds(100);
 		using (var cancellationSource = new CancellationTokenSource(timeout))
 		{
@@ -949,15 +981,14 @@ public class SshSession : IDisposable
 		{
 			await Protocol!.HandleNewKeysMessageAsync(cancellation).ConfigureAwait(false);
 
-			try
+			if (Algorithms!.IsExtensionInfoRequested)
+			{
+				await SendExtensionInfoAsync(cancellation).ConfigureAwait(false);
+			}
+
+			if (!Reconnecting)
 			{
 				await ContinueSendBlockedMessagesAsync(cancellation).ConfigureAwait(false);
-			}
-			catch (Exception ex)
-			{
-				Trace.TraceEvent(
-					TraceEventType.Error, SshTraceEventIds.SendMessageFailed, ex.ToString());
-				await CloseAsync(SshDisconnectReason.ProtocolError, ex).ConfigureAwait(false);
 			}
 		}
 		finally
@@ -1398,6 +1429,11 @@ public class SshSession : IDisposable
 	/// </summary>
 	internal async Task SendExtensionInfoAsync(CancellationToken cancellation)
 	{
+		if (Protocol == null)
+		{
+			return;
+		}
+
 		var extensionInfo = new Dictionary<string, string>();
 
 		foreach (var extensionName in Config.ProtocolExtensions)
@@ -1417,7 +1453,7 @@ public class SshSession : IDisposable
 			}
 		}
 
-		await SendMessageAsync(
+		await Protocol.SendMessageAsync(
 			new ExtensionInfoMessage { ExtensionInfo = extensionInfo }, cancellation)
 			.ConfigureAwait(false);
 	}

--- a/src/cs/Ssh/SshSessionAlgorithms.cs
+++ b/src/cs/Ssh/SshSessionAlgorithms.cs
@@ -28,6 +28,12 @@ internal class SshSessionAlgorithms : IDisposable
 
 	public CompressionAlgorithm? Decompressor { get; set; }
 
+	/// <summary>
+	/// Flag from the initial key exchange indicating whether the other side supports and is
+	/// requesting protocol extension info.
+	/// </summary>
+	public bool IsExtensionInfoRequested { get; set; }
+
 	public void Dispose()
 	{
 		Dispose(true);

--- a/src/ts/ssh/io/sshProtocol.ts
+++ b/src/ts/ssh/io/sshProtocol.ts
@@ -66,6 +66,7 @@ export class SshProtocol implements Disposable {
 		private readonly trace: Trace,
 	) {
 		this.stream = stream;
+		this.traceChannelData = config.traceChannelData;
 	}
 
 	/* @internal */

--- a/src/ts/ssh/secureStream.ts
+++ b/src/ts/ssh/secureStream.ts
@@ -312,7 +312,8 @@ export class SecureStream extends Duplex implements Disposable {
 		if (!this.disposed) {
 			this.disposed = true;
 
-			await this.session.close(SshDisconnectReason.none, 'SshSession disposed');
+			await this.session.close(
+				SshDisconnectReason.none, this.session.constructor.name + ' disposed.');
 			this.session.dispose();
 			this.unsubscribe();
 

--- a/src/ts/ssh/services/keyExchangeService.ts
+++ b/src/ts/ssh/services/keyExchangeService.ts
@@ -49,6 +49,7 @@ class ExchangeContext {
 	public exchangeValue?: Buffer;
 	public exchange?: KeyExchange;
 	public newAlgorithms?: SshSessionAlgorithms;
+	public isExtensionInfoRequested?: boolean;
 }
 
 const serverExtensionInfoSignal = 'ext-info-s';
@@ -94,9 +95,24 @@ export class KeyExchangeService extends SshService {
 	}
 
 	public finishKeyExchange(): SshSessionAlgorithms {
+		if (!this.exchangeContext) {
+			throw new SshConnectionError(
+				'Key exchange not started.',
+				SshDisconnectReason.protocolError,
+			);
+		}
+
 		const newAlgorithms = this.exchangeContext!.newAlgorithms;
+		if (!newAlgorithms) {
+			throw new SshConnectionError(
+				'Key exchange not completed.',
+				SshDisconnectReason.protocolError,
+			);
+		}
+
+		newAlgorithms.isExtensionInfoRequested = this.exchangeContext?.isExtensionInfoRequested;
 		this.exchangeContext = null;
-		return <SshSessionAlgorithms>newAlgorithms;
+		return newAlgorithms;
 	}
 
 	public abortKeyExchange(): void {
@@ -111,15 +127,13 @@ export class KeyExchangeService extends SshService {
 		const message = new KeyExchangeInitMessage();
 		message.keyExchangeAlgorithms = algorithmNames(config.keyExchangeAlgorithms).concat(extinfo);
 		message.serverHostKeyAlgorithms = this.getPublicKeyAlgorithms();
-		message.encryptionAlgorithmsClientToServer = message.encryptionAlgorithmsServerToClient = algorithmNames(
-			config.encryptionAlgorithms,
-		);
+		message.encryptionAlgorithmsClientToServer = message.encryptionAlgorithmsServerToClient =
+			algorithmNames(config.encryptionAlgorithms);
 		message.macAlgorithmsClientToServer = message.macAlgorithmsServerToClient = algorithmNames(
 			config.hmacAlgorithms,
 		);
-		message.compressionAlgorithmsClientToServer = message.compressionAlgorithmsServerToClient = algorithmNames(
-			config.compressionAlgorithms,
-		);
+		message.compressionAlgorithmsClientToServer = message.compressionAlgorithmsServerToClient =
+			algorithmNames(config.compressionAlgorithms);
 		message.languagesClientToServer = [''];
 		message.languagesServerToClient = [''];
 		message.firstKexPacketFollows = false;
@@ -262,46 +276,44 @@ export class KeyExchangeService extends SshService {
 
 			// Check if the negotiated algorithm is the one preferred by THIS side.
 			// This means if there was a "guess" at kex initialization then it was correct.
-			const negotiatedKexAlgorthmIsPreferred =
+			const negotiatedKexAlgorithmIsPreferred =
 				this.exchangeContext.keyExchange === config.keyExchangeAlgorithms[0]?.name;
 
 			// If a guess was not sent, or the guess was wrong, send the init message now.
-			if (!alreadySentGuess || !negotiatedKexAlgorthmIsPreferred) {
+			if (!alreadySentGuess || !negotiatedKexAlgorithmIsPreferred) {
 				const kexAlgorithm = config.getKeyExchangeAlgorithm(this.exchangeContext.keyExchange!)!;
 				this.exchangeContext.exchange = kexAlgorithm.createKeyExchange();
-				this.exchangeContext.exchangeValue = await this.exchangeContext.exchange.startKeyExchange();
+				this.exchangeContext.exchangeValue =
+					await this.exchangeContext.exchange.startKeyExchange();
 
 				const reply = new KeyExchangeDhInitMessage();
 				reply.e = this.exchangeContext.exchangeValue;
 				await this.session.sendMessage(reply, cancellation);
 			}
 
-			extensionInfoSignal = serverExtensionInfoSignal;
+			this.exchangeContext.isExtensionInfoRequested =
+				this.isInitialExchange &&
+				message.keyExchangeAlgorithms?.includes(serverExtensionInfoSignal);
 		} else {
 			if (message.firstKexPacketFollows) {
 				// The remote side indicated it is sending a guess immediately following.
 				// Check if the negotiated algorithm is the one preferred by the OTHER side.
 				// If so, the following "guess" will be correct. Otherwise it must be ignored.
-				const negotiatedKexAlgorthmIsPreferred =
+				const negotiatedKexAlgorithmIsPreferred =
 					this.exchangeContext.keyExchange === message.keyExchangeAlgorithms?.[0];
-				const guessResult = negotiatedKexAlgorthmIsPreferred ? 'correct' : 'incorrect';
+				const guessResult = negotiatedKexAlgorithmIsPreferred ? 'correct' : 'incorrect';
 				this.trace(
 					TraceLevel.Verbose,
 					SshTraceEventIds.algorithmNegotiation,
 					`Client's KeyExchange guess was ${guessResult}.`,
 				);
-				this.exchangeContext.discardGuessedInit = !negotiatedKexAlgorthmIsPreferred;
+				this.exchangeContext.discardGuessedInit = !negotiatedKexAlgorithmIsPreferred;
 			}
 
 			this.exchangeContext.clientKexInitPayload = message.toBuffer();
-
-			extensionInfoSignal = clientExtensionInfoSignal;
-		}
-
-		if (this.isInitialExchange && message.keyExchangeAlgorithms!.includes(extensionInfoSignal)) {
-			// The extension info message will be blocked in the queue
-			// until immediately after the key-exchange is done.
-			await this.session.sendExtensionInfo(cancellation);
+			this.exchangeContext.isExtensionInfoRequested =
+				this.isInitialExchange &&
+				message.keyExchangeAlgorithms?.includes(clientExtensionInfoSignal);
 		}
 	}
 

--- a/src/ts/ssh/services/keyExchangeService.ts
+++ b/src/ts/ssh/services/keyExchangeService.ts
@@ -289,6 +289,12 @@ export class KeyExchangeService extends SshService {
 				const reply = new KeyExchangeDhInitMessage();
 				reply.e = this.exchangeContext.exchangeValue;
 				await this.session.sendMessage(reply, cancellation);
+			} else {
+				this.trace(
+					TraceLevel.Verbose,
+					SshTraceEventIds.algorithmNegotiation,
+					'Already sent correct guess for key-exchange init.',
+				);
 			}
 
 			this.exchangeContext.isExtensionInfoRequested =

--- a/src/ts/ssh/sshClientSession.ts
+++ b/src/ts/ssh/sshClientSession.ts
@@ -503,7 +503,7 @@ export class SshClientSession extends SshSession {
 		this.trace(
 			TraceLevel.Info,
 			SshTraceEventIds.clientSessionReconnecting,
-			`{this} reconnected. Re-sent ${count} dropped messages.`,
+			`${this} reconnected. Re-sent ${count} dropped messages.`,
 		);
 	}
 

--- a/src/ts/ssh/sshServerSession.ts
+++ b/src/ts/ssh/sshServerSession.ts
@@ -134,7 +134,7 @@ export class SshServerSession extends SshSession {
 		if (!this.reconnectableSessions) {
 			throw new Error(
 				'Disconnected sessions collection ' +
-					'should have been initialied when reconnect is enabled.',
+					'should have been initialized when reconnect is enabled.',
 			);
 		}
 
@@ -224,7 +224,7 @@ export class SshServerSession extends SshSession {
 			}
 
 			// Now this server session is invalid because the client reconnected to another one.
-			this.dispose();
+			this.dispose(new SshConnectionError('Reconnected.', SshDisconnectReason.none));
 		} finally {
 			reconnectSession.reconnecting = false;
 		}
@@ -253,7 +253,12 @@ export class SshServerSession extends SshSession {
 		reconnectSession.reconnectedEmitter.fire();
 	}
 
-	public dispose(): void {
+	public dispose(): void;
+
+	/* @internal */
+	public dispose(error?: Error): void;
+
+	public dispose(error?: Error): void {
 		if (this.reconnectableSessions) {
 			const index = this.reconnectableSessions.indexOf(this);
 			if (index >= 0) {
@@ -261,6 +266,6 @@ export class SshServerSession extends SshSession {
 			}
 		}
 
-		super.dispose();
+		super.dispose(error);
 	}
 }

--- a/src/ts/ssh/sshSessionAlgorithms.ts
+++ b/src/ts/ssh/sshSessionAlgorithms.ts
@@ -22,6 +22,7 @@ export class SshSessionAlgorithms implements Disposable {
 	public messageVerifier?: MessageVerifier | null;
 	public compressor?: CompressionAlgorithm | null;
 	public decompressor?: CompressionAlgorithm | null;
+	public isExtensionInfoRequested?: boolean;
 
 	public dispose(): void {
 		if (this.cipher) this.cipher.dispose();

--- a/test/cs/Ssh.Test/MetricsTests.cs
+++ b/test/cs/Ssh.Test/MetricsTests.cs
@@ -143,8 +143,9 @@ public class MetricsTests : IDisposable
 		await this.clientSession.CloseAsync(SshDisconnectReason.ByApplication);
 		await this.serverSession.CloseAsync(SshDisconnectReason.ByApplication);
 
-		Assert.Equal(0, this.clientSession.Metrics.LatencyCurrentMs);
-		Assert.Equal(0, this.serverSession.Metrics.LatencyCurrentMs);
+		await TaskExtensions.WaitUntil(() =>
+			this.clientSession.Metrics.LatencyCurrentMs == 0 &&
+			this.serverSession.Metrics.LatencyCurrentMs == 0).WithTimeout(Timeout);
 	}
 
 	[Fact]

--- a/test/cs/Ssh.Test/MultiChannelStreamTests.cs
+++ b/test/cs/Ssh.Test/MultiChannelStreamTests.cs
@@ -86,7 +86,7 @@ public class MultiChannelStreamTests
 		{
 			Assert.Equal(server, sender);
 			Assert.Equal(SshDisconnectReason.None, e.Reason);
-			Assert.Equal(typeof(SshSession).Name + " disposed", e.Message);
+			Assert.Equal(typeof(SshSession).Name + " disposed.", e.Message);
 			Assert.IsType<SshConnectionException>(e.Exception);
 			Assert.Equal(
 				SshDisconnectReason.None,

--- a/test/cs/Ssh.Test/ReconnectTests.cs
+++ b/test/cs/Ssh.Test/ReconnectTests.cs
@@ -768,7 +768,7 @@ public class ReconnectTests : IDisposable
 		await ReconnectAsync();
 
 		// Wait for a few more messages to be exchanged.
-		await Task.Delay(100);
+		await Task.Delay(400);
 
 		// Verify some messages were received after reconnection.
 		Assert.True(serverChannel.Metrics.BytesReceived > serverBytesReceivedBeforeReconnect);

--- a/test/cs/Ssh.Test/ReconnectTests.cs
+++ b/test/cs/Ssh.Test/ReconnectTests.cs
@@ -716,25 +716,26 @@ public class ReconnectTests : IDisposable
 				var message = BitConverter.GetBytes(receiveCount);
 				try
 				{
-					channel.Session.Trace.TraceInformation($"{name} sending *{receiveCount:x2}");
+					channel.Session.Trace.TraceInformation($"{name} sending {receiveCount:x2}");
 					await stream.WriteAsync(message, 0, message.Length, cancellation)
 						.WithTimeout(Timeout);
 					sent = true;
-					channel.Session.Trace.TraceInformation($"{name} receiving *{receiveCount:x2}");
+					channel.Session.Trace.TraceInformation($"{name} receiving {receiveCount:x2}");
 					await stream.ReadAsync(receiveBuffer, 0, receiveBuffer.Length, cancellation)
 						.WithTimeout(Timeout);
 					Assert.Equal(receiveCount, BitConverter.ToInt32(receiveBuffer, 0));
-					channel.Session.Trace.TraceInformation($"{name} verified *{receiveCount:x2}");
+					channel.Session.Trace.TraceInformation($"{name} verified {receiveCount:x2}");
 				}
 				catch (OperationCanceledException) when (cancellation.IsCancellationRequested)
 				{
 					break;
 				}
-				catch (Exception)
+				catch (Exception ex)
 				{
-					channel.Session.Trace.TraceInformation(
-						$"{name} failed to {(sent ? "receive" : "send")} *{receiveCount:x2}");
-
+					channel.Session.Trace.TraceEvent(
+						System.Diagnostics.TraceEventType.Error,
+						0,
+						$"{name} failed to {(sent ? "receive" : "send")} {receiveCount:x2}: {ex}");
 					stream.Close();
 					throw;
 				}

--- a/test/cs/Ssh.Test/ReconnectTests.cs
+++ b/test/cs/Ssh.Test/ReconnectTests.cs
@@ -767,12 +767,11 @@ public class ReconnectTests : IDisposable
 
 		await ReconnectAsync();
 
-		// Wait for a few more messages to be exchanged.
-		await Task.Delay(400);
-
 		// Verify some messages were received after reconnection.
-		Assert.True(serverChannel.Metrics.BytesReceived > serverBytesReceivedBeforeReconnect);
-		Assert.True(clientChannel.Metrics.BytesReceived > clientBytesReceivedBeforeReconnect);
+		await TaskExtensions.WaitUntil(() =>
+			 serverChannel.Metrics.BytesReceived > serverBytesReceivedBeforeReconnect &&
+				clientChannel.Metrics.BytesReceived > clientBytesReceivedBeforeReconnect)
+			.WithTimeout(Timeout);
 
 		streamCancellationSource.Cancel();
 		int clientPacketsReceived = await clientStreamTask;

--- a/test/cs/Ssh.Test/SecureStreamTests.cs
+++ b/test/cs/Ssh.Test/SecureStreamTests.cs
@@ -227,7 +227,7 @@ public class SecureStreamTests
 		{
 			Assert.Equal(server, sender);
 			Assert.Equal(SshDisconnectReason.None, e.Reason);
-			Assert.Equal(typeof(SshServerSession).Name + " disposed", e.Message);
+			Assert.Equal(typeof(SshServerSession).Name + " disposed.", e.Message);
 			closedEventRaised = true;
 		};
 

--- a/test/cs/Ssh.Test/SessionPair.cs
+++ b/test/cs/Ssh.Test/SessionPair.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Microsoft.DevTunnels.Ssh.Algorithms;
 using Nerdbank.Streams;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Microsoft.DevTunnels.Ssh.Test;
 
@@ -20,6 +21,16 @@ class SessionPair : IDisposable
 		SshSessionConfiguration serverConfig = null,
 		SshSessionConfiguration clientConfig = null,
 		ICollection<SshServerSession> disconnectedSessions = null)
+		: this(testOutput: null, serverConfig, clientConfig, disconnectedSessions)
+	{
+
+	}
+
+	public SessionPair(
+		ITestOutputHelper testOutput,
+		SshSessionConfiguration serverConfig = null,
+		SshSessionConfiguration clientConfig = null,
+		ICollection<SshServerSession> disconnectedSessions = null)
 	{
 		if (serverConfig == null)
 		{
@@ -30,6 +41,13 @@ class SessionPair : IDisposable
 		if (clientConfig == null)
 		{
 			clientConfig = serverConfig;
+		}
+
+		if (testOutput != null)
+		{
+			var testOutputListener = new TestOutputTraceListener(testOutput);
+			ClientTrace.Listeners.Add(testOutputListener);
+			ServerTrace.Listeners.Add(testOutputListener);
 		}
 
 		ClientTrace.Switch.Level = SourceLevels.All;

--- a/test/cs/Ssh.Test/TestOutputTraceListener.cs
+++ b/test/cs/Ssh.Test/TestOutputTraceListener.cs
@@ -1,0 +1,47 @@
+﻿using Microsoft;
+using System.Diagnostics;
+using System.Text;
+using System;
+using Xunit.Abstractions;
+
+/// <summary>
+/// A trace listener that writes to Xunit's test output.
+/// </summary>
+public class TestOutputTraceListener : TraceListener
+{
+	private readonly StringBuilder lineBuilder = new();
+
+	public TestOutputTraceListener(ITestOutputHelper testOutput)
+	{
+		TestOutput = Requires.NotNull(testOutput, nameof(testOutput));
+	}
+
+	public ITestOutputHelper TestOutput { get; }
+
+	public override void Write(string message)
+	{
+		lock (this.lineBuilder)
+		{
+			this.lineBuilder.Append(message);
+		}
+	}
+
+	public override void WriteLine(string message)
+	{
+		lock (this.lineBuilder)
+		{
+			this.lineBuilder.Append(message);
+
+			try
+			{
+				TestOutput.WriteLine(this.lineBuilder.ToString());
+			}
+			catch (InvalidOperationException)
+			{
+				// This can happen if the test has already completed.
+			}
+
+			this.lineBuilder.Clear();
+		}
+	}
+}

--- a/test/ts/ssh-test/reconnectTests.ts
+++ b/test/ts/ssh-test/reconnectTests.ts
@@ -845,7 +845,7 @@ export class ReconnectTests {
 		await this.doReconnect();
 
 		// Wait for a few more messages to be exchanged.
-		await new Promise((c) => setTimeout(c, 100));
+		await new Promise((c) => setTimeout(c, 200));
 
 		// Verify some messages were received after reconnection.
 		assert(serverChannel.metrics.bytesReceived > serverBytesReceivedBeforeReconnect);

--- a/test/ts/ssh-test/secureStreamTests.ts
+++ b/test/ts/ssh-test/secureStreamTests.ts
@@ -17,6 +17,7 @@ import {
 	SshDisconnectReason,
 	SshServerCredentials,
 	SshServerSession,
+	SshSessionClosedEventArgs,
 	Stream,
 } from '@microsoft/dev-tunnels-ssh';
 import { MockNetworkStream } from './mockNetworkStream';
@@ -207,11 +208,9 @@ export class SecureStreamTests {
 	}) {
 		const [server, client] = await this.connect();
 
-		let closedEventRaised = false;
+		let closedEvent: SshSessionClosedEventArgs = undefined!;
 		server.onClosed((e) => {
-			assert.equal(e.reason, SshDisconnectReason.none);
-			assert.equal(e.message, 'SshSession disposed');
-			closedEventRaised = true;
+			closedEvent = e;
 		});
 
 		if (isConnected) {
@@ -221,7 +220,9 @@ export class SecureStreamTests {
 		await SecureStreamTests.disposeSecureStream(server, disposeAsync);
 
 		assert(server.isClosed);
-		assert(closedEventRaised);
+		assert(closedEvent);
+		assert.equal(closedEvent.reason, SshDisconnectReason.none);
+		assert.equal(closedEvent.message, 'SshServerSession disposed.');
 	}
 
 	private static async disposeSecureStream(stream: SecureStream, disposeAsync: boolean) {


### PR DESCRIPTION
Reconnection could result in dropped or out-of-order packets sometimes, if the SSH client was trying to send packets at the same time as the reconnect protocol negotiation. The fix is to defer any other messages being sent until after the reconnect has completed (the same way messages are deferred during key-exchange).

The problem did not occur if only the server was sending messages during reconnection, due to how reconnection on the server side swaps out the `SshServerSession` instance being reconnected, unlike the client reconnection where the same session instance is used the whole time.

The problem also did not occur in TypeScript due to the single-threaded execution environment there. However, I still ported some of the refactoring from C# to TS to keep the codebases consistent.