### PR TITLE
Fix port-forwarding to IPv6 localhost

### DIFF
--- a/.pipelines/dev-tunnels-ssh-ci.yaml
+++ b/.pipelines/dev-tunnels-ssh-ci.yaml
@@ -274,11 +274,6 @@ jobs:
           selectOrConfig: config
           nugetConfigPath: NuGet.config
 
-      - task: NodeTool@0
-        displayName: Use Node 14.x
-        inputs:
-          versionSpec: 14.x
-
       - task: Npm@1
         displayName: Restore npm packages
         inputs:

--- a/bench/cs/Ssh.Benchmark/Benchmark.cs
+++ b/bench/cs/Ssh.Benchmark/Benchmark.cs
@@ -49,6 +49,10 @@ public abstract class Benchmark : IAsyncDisposable
 		benchmarks.Add("unencrypted-200", () => new ThroughputBenchmark(t, messageSize: 200, withEncryption: false));
 		benchmarks.Add("unencrypted-50000", () => new ThroughputBenchmark(t, messageSize: 50_000, withEncryption: false));
 		benchmarks.Add("unencrypted-1000000", () => new ThroughputBenchmark(t, messageSize: 1_000_000, withEncryption: false));
+		benchmarks.Add("portforward-ipv4", () => new PortForwardBenchmark(IPAddress.Loopback, IPAddress.Loopback.ToString()));
+		benchmarks.Add("portforward-ipv4-localhost", () => new PortForwardBenchmark(IPAddress.Loopback, "localhost"));
+		benchmarks.Add("portforward-ipv6", () => new PortForwardBenchmark(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback.ToString()));
+		benchmarks.Add("portforward-ipv6-localhost", () => new PortForwardBenchmark(IPAddress.IPv6Loopback, "localhost"));
 
 		var stopwatch = new Stopwatch();
 

--- a/bench/cs/Ssh.Benchmark/PortForwardBenchmark.cs
+++ b/bench/cs/Ssh.Benchmark/PortForwardBenchmark.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Diagnostics;
+using System.Net;
+using System.Net.Sockets;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.DevTunnels.Ssh.Events;
+using Microsoft.DevTunnels.Ssh.Messages;
+using Microsoft.DevTunnels.Ssh.Tcp;
+using Microsoft.DevTunnels.Ssh.Tcp.Events;
+
+namespace Microsoft.DevTunnels.Ssh.Benchmark;
+
+#if NETSTANDARD2_0 || NET4
+using ValueTask = System.Threading.Tasks.Task;
+#endif
+
+class PortForwardBenchmark : Benchmark
+{
+	private const string ConnectTimeMeasurement = "Connect time (ms)";
+
+	private readonly IPAddress listenAddress;
+	private readonly string hostAddress;
+
+	private readonly SshServer server;
+	private readonly Task serverTask;
+	private readonly SshClient client;
+
+	public PortForwardBenchmark(IPAddress listenAddress, string hostAddress)
+		: base($"Port forward to {hostAddress} ({listenAddress})")
+	{
+		HigherIsBetter[ConnectTimeMeasurement] = false;
+
+		this.listenAddress = listenAddress;
+		this.hostAddress = hostAddress;
+
+		var config = new SshSessionConfiguration();
+		config.AddService(typeof(PortForwardingService));
+
+		var trace = new TraceSource(nameof(PortForwardBenchmark));
+		this.server = new SshServer(config, trace);
+		this.client = new SshClient(config, trace);
+
+		var serverKey = SshAlgorithms.PublicKey.RsaWithSha512.GenerateKeyPair();
+		this.server.Credentials = new[] { serverKey };
+
+		this.server.SessionAuthenticating += OnServerSessionAuthenticating;
+
+		this.serverTask = this.server.AcceptSessionsAsync(Benchmark.ServerPort, IPAddress.Loopback);
+	}
+
+	protected override async Task RunAsync(Stopwatch stopwatch)
+	{
+		var serverSessionCompletion = new TaskCompletionSource<SshServerSession>();
+		EventHandler<SshServerSession> sessionOpenedHandler = null;
+		sessionOpenedHandler = (sender, session) =>
+		{
+			serverSessionCompletion.SetResult(session);
+			this.server.SessionOpened -= sessionOpenedHandler;
+		};
+		this.server.SessionOpened += sessionOpenedHandler;
+
+		var clientSession = await this.client.OpenSessionAsync(
+			IPAddress.Loopback.ToString(), ServerPort);
+		clientSession.Authenticating += OnClientSessionAuthenticating;
+		clientSession.Request += OnClientSessionRequest;
+		await clientSession.AuthenticateAsync(("benchmark", (string)null));
+		var serverSession = await serverSessionCompletion.Task;
+
+		var connectServer = new TcpListener(this.listenAddress, 0);
+		connectServer.Start();
+		var serverPort = ((IPEndPoint)connectServer.LocalEndpoint).Port;
+
+		var availablePortListener = new TcpListener(IPAddress.Loopback, 0);
+		availablePortListener.Start();
+		var clientPort = ((IPEndPoint)availablePortListener.LocalEndpoint).Port;
+		availablePortListener.Stop();
+
+		var forwarder = await serverSession.ForwardFromRemotePortAsync(
+			IPAddress.Loopback, clientPort, this.hostAddress, serverPort);
+		if (forwarder == null)
+		{
+			throw new InvalidOperationException("Failed to forward port");
+		}
+
+		var channelOpenedCompletion = new TaskCompletionSource<ForwardedPortChannelEventArgs>();
+		clientSession.GetService<PortForwardingService>().RemoteForwardedPorts.PortChannelAdded +=
+			(sender, e) => channelOpenedCompletion.SetResult(e);
+
+		var connectClient = new TcpClient();
+		double connectStartMark = stopwatch.Elapsed.TotalMilliseconds;
+
+		var clientConnectTask = connectClient.ConnectAsync(IPAddress.Loopback, clientPort);
+		var serverAcceptTask = connectServer.AcceptTcpClientAsync();
+		await Task.WhenAll(clientConnectTask, serverAcceptTask, channelOpenedCompletion.Task);
+		double connectEndMark = stopwatch.Elapsed.TotalMilliseconds;
+		connectServer.Stop();
+
+		AddMeasurement(ConnectTimeMeasurement, connectEndMark - connectStartMark);
+	}
+
+	private void OnClientSessionAuthenticating(object sender, SshAuthenticatingEventArgs e)
+	{
+		e.AuthenticationTask = Task.FromResult(new ClaimsPrincipal());
+	}
+
+	private void OnServerSessionAuthenticating(object sender, SshAuthenticatingEventArgs e)
+	{
+		e.AuthenticationTask = Task.FromResult(new ClaimsPrincipal());
+	}
+
+	private void OnClientSessionRequest(object sender, SshRequestEventArgs<SessionRequestMessage> e)
+	{
+		e.IsAuthorized = true;
+	}
+
+	public override async ValueTask DisposeAsync()
+	{
+		this.server.Dispose();
+		this.client.Dispose();
+		await this.serverTask;
+	}
+}

--- a/bench/ts/ssh-bench/main.ts
+++ b/bench/ts/ssh-bench/main.ts
@@ -6,6 +6,7 @@ import * as yargs from 'yargs';
 import { Benchmark } from './benchmark';
 import { SessionSetupBenchmark } from './sessionSetupBenchmark';
 import { ThroughputBenchmark } from './throughputBenchmark';
+import { PortForwardBenchmark } from './portForwardBenchmark';
 import 'source-map-support/register';
 
 main()
@@ -58,6 +59,13 @@ async function main(): Promise<number> {
 	benchmarks.set('unencrypted-200', () => new ThroughputBenchmark(t, 200, false));
 	benchmarks.set('unencrypted-50000', () => new ThroughputBenchmark(t, 50000, false));
 	benchmarks.set('unencrypted-1000000', () => new ThroughputBenchmark(t, 1000000, false));
+	benchmarks.set('portforward-ipv4', () => new PortForwardBenchmark('127.0.0.1', '127.0.0.1'));
+	benchmarks.set(
+		'portforward-ipv4-localhost',
+		() => new PortForwardBenchmark('127.0.0.1', 'localhost'),
+	);
+	benchmarks.set('portforward-ipv6', () => new PortForwardBenchmark('::1', '::1'));
+	benchmarks.set('portforward-ipv6-localhost', () => new PortForwardBenchmark('::1', 'localhost'));
 
 	for (let [benchmarkName, benchmarkFunc] of benchmarks.entries()) {
 		if (nameList && !nameList.includes(benchmarkName)) {

--- a/bench/ts/ssh-bench/portForwardBenchmark.ts
+++ b/bench/ts/ssh-bench/portForwardBenchmark.ts
@@ -1,0 +1,151 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//
+
+import * as net from 'net';
+import { Benchmark } from './benchmark';
+import {
+	SshClientCredentials,
+	SshSessionConfiguration,
+	SshAlgorithms,
+	PromiseCompletionSource,
+	SshServerSession,
+} from '@microsoft/dev-tunnels-ssh';
+import {
+	ForwardedPortChannelEventArgs,
+	PortForwardingService,
+	SshClient,
+	SshServer,
+} from '@microsoft/dev-tunnels-ssh-tcp';
+
+const ConnectTimeMeasurement = 'Connect time (ms)';
+
+declare type hrtime = [number, number];
+const millis = ([s, ns]: hrtime) => s * 1000 + ns / 1000000;
+
+export class PortForwardBenchmark extends Benchmark {
+	private readonly hostAddress: string;
+	private readonly listenAddress: string;
+	private readonly port: number;
+	private readonly initPromise: Promise<void>;
+	private readonly server: SshServer;
+	private readonly serverPromise: Promise<void>;
+	private readonly client: SshClient;
+
+	public constructor(listenAddress: string, hostAddress: string) {
+		super(`Port forward to ${hostAddress} (${listenAddress})`);
+
+		this.higherIsBetter.set(ConnectTimeMeasurement, false);
+
+		this.hostAddress = hostAddress;
+		this.listenAddress = listenAddress;
+
+		const config = new SshSessionConfiguration();
+		config.addService(PortForwardingService);
+
+		this.server = new SshServer(config);
+		this.client = new SshClient(config);
+
+		////this.server.trace = (_, __, msg) => console.log('SERVER: ' + msg);
+		////this.client.trace = (_, __, msg) => console.log('CLIENT: ' + msg);
+
+		this.initPromise = SshAlgorithms.publicKey
+			.rsaWithSha512!.generateKeyPair()
+			.then((serverKey) => {
+				this.server.credentials.publicKeys.push(serverKey);
+			});
+
+		this.server.onSessionOpened((session) => {
+			session.onAuthenticating((e) => {
+				e.authenticationPromise = Promise.resolve({});
+			});
+		});
+
+		this.port = Benchmark.findAvailablePort();
+		this.serverPromise = this.server.acceptSessions(this.port, '127.0.0.1');
+	}
+
+	public async run(): Promise<void> {
+		await this.initPromise;
+
+		const startTime: hrtime = process.hrtime();
+
+		const serverSessionCompletion = new PromiseCompletionSource<SshServerSession>();
+		const sessionOpenedRegistration = this.server.onSessionOpened((session) => {
+			serverSessionCompletion.resolve(session);
+			sessionOpenedRegistration.dispose();
+		});
+
+		var clientSession = await this.client.openSession('127.0.0.1', this.port);
+		clientSession.onAuthenticating((e) => {
+			e.authenticationPromise = Promise.resolve({});
+		});
+		await clientSession.authenticate({ username: 'benchmark' });
+		clientSession.onRequest((e) => {
+			e.isAuthorized = true;
+		});
+
+		const serverSession = await serverSessionCompletion.promise;
+
+		const connectServer = new net.Server();
+		const listeningCompletion = new PromiseCompletionSource<void>();
+		connectServer.listen(0, this.listenAddress, undefined, () => listeningCompletion.resolve());
+		await listeningCompletion.promise;
+		const serverPort = (<net.AddressInfo>connectServer.address()).port;
+
+		const availableServer = new net.Server();
+		const availableCompletion = new PromiseCompletionSource<void>();
+		availableServer.listen(0, this.listenAddress, undefined, () => availableCompletion.resolve());
+		await availableCompletion.promise;
+		const clientPort = (<net.AddressInfo>availableServer.address()).port;
+		await new Promise<void>((resolve, reject) => {
+			availableServer.close((err) => (err ? reject(err) : resolve()));
+		});
+
+		const serverPfs = serverSession.activateService(PortForwardingService);
+		const forwarder = await serverPfs.forwardFromRemotePort(
+			'127.0.0.1',
+			clientPort,
+			this.hostAddress,
+			serverPort,
+		);
+		if (!forwarder) throw new Error('Failed to forward port.');
+
+		const channelOpenedCompletion = new PromiseCompletionSource<ForwardedPortChannelEventArgs>();
+		const clientPfs = clientSession.activateService(PortForwardingService);
+		clientPfs.remoteForwardedPorts.onPortChannelAdded((e) => channelOpenedCompletion.resolve(e));
+
+		const connectClient = new net.Socket();
+		const connectStartMark: hrtime = process.hrtime(startTime);
+
+		const serverAcceptPromise = new Promise<void>((resolve, reject) => {
+			connectServer.on('error', reject).once('connection', resolve);
+		});
+		const connectClientPromise = new Promise<void>((resolve, reject) => {
+			connectClient.on('error', reject).connect(clientPort, '127.0.0.1', resolve);
+		});
+		await Promise.all([
+			connectClientPromise,
+			serverAcceptPromise,
+			channelOpenedCompletion.promise,
+		]);
+
+		const connectEndMark: hrtime = process.hrtime(startTime);
+
+		connectClient.end();
+		await new Promise<void>((resolve, reject) => {
+			connectServer.close((err) => (err ? reject(err) : resolve()));
+		});
+
+		this.addMeasurement(
+			ConnectTimeMeasurement,
+			millis(connectEndMark) - millis(connectStartMark),
+		);
+	}
+
+	public async dispose(): Promise<void> {
+		this.server.dispose();
+		this.client.dispose();
+		await this.serverPromise;
+	}
+}

--- a/src/cs/Ssh.Tcp/Services/LocalPortForwarder.cs
+++ b/src/cs/Ssh.Tcp/Services/LocalPortForwarder.cs
@@ -269,10 +269,12 @@ public class LocalPortForwarder : SshService
 
 		var originatorEndPoint = tcpClient.Client.RemoteEndPoint as IPEndPoint;
 		var originatorAddress = originatorEndPoint?.Address?.ToString() ?? "<unknown>";
+		var message = $"{nameof(PortForwardingService)} accepted connection " +
+			$"from {originatorAddress} at {listener.LocalEndpoint}.";
 		Session.Trace.TraceEvent(
 			TraceEventType.Verbose,
 			SshTraceEventIds.PortForwardConnectionAccepted,
-			$"{nameof(PortForwardingService)} accepted connection from: {originatorAddress}");
+			message);
 		return tcpClient;
 	}
 

--- a/src/cs/Ssh.Tcp/Services/PortForwardingService.cs
+++ b/src/cs/Ssh.Tcp/Services/PortForwardingService.cs
@@ -229,11 +229,9 @@ public class PortForwardingService : SshService
 	/// <param name="remotePort">The remote port to listen on, or 0 to choose an
 	/// available port. (The chosen port can then be obtained via the
 	/// <see cref="RemotePortConnector.RemotePort" /> property on the returned object.)</param>
-	/// <param name="localHost">The destination hostname or IP address for forwarded
-	/// connections, to be resolved on the local side. WARNING: Avoid using the hostname
-	/// `localhost` as the destination host; use `127.0.0.1` or `::1` instead. OpenSSH does not
-	/// recognize `localhost` as a valid destination host, and it can be slower anyway due to
-	/// a bug in .NET Core: https://github.com/dotnet/runtime/issues/31085 </param>
+	/// <param name="localHost">The destination hostname (such as `localhost`) or IP address for
+	/// forwarded connections, to be resolved on the local side. WARNING: OpenSSH does not
+	/// recognize `localhost` as a valid destination host.</param>
 	/// <param name="localPort">The destination port for forwarded connections.</param>
 	/// <param name="cancellation">Cancellation token for the request; note this cannot
 	/// cancel forwarding once it has started; use the returned disposable do do that.</param>
@@ -319,14 +317,12 @@ public class PortForwardingService : SshService
 	/// </summary>
 	/// <param name="localIPAddress">IP address of the interface to bind to on the local
 	/// side.</param>
-	/// <param name="localPort">The local port number to lsiten on, or 0 to choose an
+	/// <param name="localPort">The local port number to listen on, or 0 to choose an
 	/// available port. (The chosen port can then be obtained via the
 	/// <see cref="LocalPortForwarder.LocalPort" /> property on the returned object.)</param>
-	/// <param name="remoteHost">The destination hostname or IP address for forwarded
-	/// connections, to be resolved on the remote side. WARNING: Avoid using the hostname
-	/// `localhost` as the destination host; use `127.0.0.1` or `::1` instead. OpenSSH does not
-	/// recognize `localhost` as a valid destination host, and it can be slower anyway due to
-	/// a bug in .NET Core: https://github.com/dotnet/runtime/issues/31085 </param>
+	/// <param name="remoteHost">The destination hostname (such as `localhost`) or IP address for
+	/// forwarded connections, to be resolved on the remote side. WARNING: OpenSSH does not
+	/// recognize `localhost` as a valid destination host.</param>
 	/// <param name="remotePort">The destination port for forwarded connections.
 	/// (Must not be 0.)</param>
 	/// <param name="cancellation">Cancellation token for the request; note this cannot
@@ -458,7 +454,7 @@ public class PortForwardingService : SshService
 	/// <param name="remotePort">The destination port for forwarded connections.
 	/// (Must not be 0.)</param>
 	/// <param name="cancellation">Cancellation token for the request; note this cannot
-	/// cancel streaming once it has started; dipose the returned stream for that.</param>
+	/// cancel streaming once it has started; dispose the returned stream for that.</param>
 	/// <returns>A stream that is relayed to the remote port.</returns>
 	/// <exception cref="SshChannelException">The streaming channel could not be opened,
 	/// either because it was rejected by the remote side, or the remote connection failed.

--- a/src/cs/Ssh.Tcp/Services/RemotePortForwarder.cs
+++ b/src/cs/Ssh.Tcp/Services/RemotePortForwarder.cs
@@ -4,6 +4,7 @@ using System;
 using System.Diagnostics;
 using System.Net;
 using System.Net.Sockets;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.DevTunnels.Ssh.Events;
@@ -68,16 +69,38 @@ public class RemotePortForwarder : RemotePortConnector
 	{
 		var channel = request.Channel;
 
-		// The ChannelForwarder takes ownership of the TcpClient; it will be disposed
+		// The StreamForwarder takes ownership of the TcpClient; it will be disposed
 		// when the PortForwardingService is disposed. And the channel will be disposed when the
 		// connection ends, so the SshStream does not need to be disposed separately.
 #pragma warning disable CA2000 // Dispose objects before losing scope
-		var tcpClient = new TcpClient();
+
+		TcpClient tcpClient;
+		TcpClient? tcpClient2 = null;
+		if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+		{
+			if (IPAddress.TryParse(localHost, out var localAddress))
+			{
+				tcpClient = new TcpClient(localAddress.AddressFamily);
+			}
+			else
+			{
+				// Work around a bug in .NET on Windows: https://github.com/dotnet/runtime/issues/31085
+				// If a hostname such as "localhost" was specified (rather than an IP address), first
+				// try to connect to the hostname with IPv6, then fallback to IPv4.
+				tcpClient = new TcpClient(AddressFamily.InterNetworkV6);
+				tcpClient2 = new TcpClient(AddressFamily.InterNetwork);
+			}
+		}
+		else
+		{
+			tcpClient = new TcpClient();
+		}
 
 		// The event handler may return a transformed channel stream.
 		var forwardedStream = await pfs.OnForwardedPortConnectingAsync(
 			remotePort ?? localPort, isIncoming: true, new SshStream(channel), cancellation)
 			.ConfigureAwait(false);
+
 #pragma warning restore CA2000 // Dispose objects before losing scope
 
 		if (forwardedStream == null)
@@ -88,16 +111,16 @@ public class RemotePortForwarder : RemotePortConnector
 		}
 
 		using var cancellationRegistration = cancellation.CanBeCanceled ?
-			cancellation.Register(tcpClient.Dispose) : default;
+			cancellation.Register(() =>
+			{
+				tcpClient.Dispose();
+				tcpClient2?.Dispose();
+			}) : default;
 
 		try
 		{
-#if NET5_0 || NET6_0
-			await tcpClient.ConnectAsync(localHost, localPort, cancellation)
-#else
-			await tcpClient.ConnectAsync(localHost, localPort)
-#endif
-					.ConfigureAwait(false);
+			tcpClient = await ConnectTcpClientAsync(
+				tcpClient, tcpClient2, localHost, localPort, cancellation).ConfigureAwait(false);
 		}
 		catch (ObjectDisposedException) when (cancellation.IsCancellationRequested)
 		{
@@ -148,5 +171,118 @@ public class RemotePortForwarder : RemotePortConnector
 			SshTraceEventIds.PortForwardConnectionOpened,
 			traceMessage);
 		pfs.AddStreamForwarder(streamForwarder);
+	}
+
+	/// <summary>
+	/// Connects a TCP client or fallback TCP client, and returns the connected client instance.
+	/// </summary>
+	/// <remarks>
+	/// While .NET can automatically attempt to connect to multiple resolved IP addresses,
+	/// it is very slow to do so. See https://github.com/dotnet/runtime/issues/31085.
+	///
+	/// This method is a basic implementation of the "Happy Eyeballs" algorithm described in
+	/// https://datatracker.ietf.org/doc/html/rfc8305. Effectively this enables fast connections
+	/// to either 127.0.0.1 or ::1 when 'localhost' is specified as the hostname.
+	/// </remarks>
+	private static async Task<TcpClient> ConnectTcpClientAsync(
+		TcpClient tcpClient,
+		TcpClient? tcpClient2,
+		string host,
+		int port,
+#pragma warning disable CA1801 // Review unused parameters
+		CancellationToken cancellation)
+#pragma warning restore CA1801 // Review unused parameters
+	{
+#if NET5_0 || NET6_0
+		var connectTask = tcpClient.ConnectAsync(host, port, cancellation);
+#else
+		var connectTask = tcpClient.ConnectAsync(host, port);
+#endif
+
+		if (tcpClient2 == null)
+		{
+			// There is no fallback TCP client. Just await the result of the first connection attempt.
+			await connectTask.ConfigureAwait(false);
+			return tcpClient;
+		}
+
+		// Try to connect with the first TCP client. But if it fails or takes longer than
+		// the delay time then try the second one and return whichever one connects first.
+
+		// Use a short delay when connecting to localhost. Otherwise use the recommended delay
+		// according to https://datatracker.ietf.org/doc/html/rfc8305#section-5
+		var connectionAttemptDelay = (host == "localhost" ? 10 : 250);
+
+		// Note Task.WhenAny() never throws; it returns whichever task completed or faulted first.
+		var completedOrFaultedTask = await Task.WhenAny(
+			connectTask, Task.Delay(connectionAttemptDelay, cancellation)).ConfigureAwait(false);
+		if (completedOrFaultedTask == connectTask)
+		{
+			if (completedOrFaultedTask.IsCompleted)
+			{
+				// The first connection attempt succeeded before the attempt delay elapsed.
+				// There's no need to try the second TCP client.
+				tcpClient2.Dispose();
+				return tcpClient;
+			}
+			else
+			{
+				// The first connection attempt failed before the attempt delay elapsed.
+				// Just try the second TCP client, which may or may not succeed.
+				tcpClient.Dispose();
+				return await ConnectTcpClientAsync(tcpClient2, null, host, port, cancellation)
+					.ConfigureAwait(false);
+			}
+		}
+		else
+		{
+			cancellation.ThrowIfCancellationRequested();
+
+			// The first connection attempt did not succeed or fail before the connection delay
+			// elapsed. Start the fallback connection attempt, and return whichever TCP client
+			// succeeds first (if any).
+#if NET5_0 || NET6_0
+			var connectTask2 = tcpClient2.ConnectAsync(host, port, cancellation);
+#else
+			var connectTask2 = tcpClient2.ConnectAsync(host, port);
+#endif
+
+			completedOrFaultedTask = await Task.WhenAny(connectTask, connectTask2)
+				.ConfigureAwait(false);
+			if (completedOrFaultedTask == connectTask)
+			{
+				if (completedOrFaultedTask.IsCompleted)
+				{
+					// The first connection attempt succeeded before the second one.
+					tcpClient2.Dispose();
+					return tcpClient;
+				}
+				else
+				{
+					// The first connection attempt failed (after the attempt delay elapsed).
+					// Just wait for the second one, which may or may not succeed.
+					tcpClient.Dispose();
+					await connectTask2.ConfigureAwait(false);
+					return tcpClient2;
+				}
+			}
+			else
+			{
+				if (completedOrFaultedTask.IsCompleted)
+				{
+					// The second connection attempt succeeded before the first one.
+					tcpClient.Dispose();
+					return tcpClient2;
+				}
+				else
+				{
+					// The second connection attempt failed.
+					// Just wait for the first one, which may or may not succeed.
+					tcpClient2.Dispose();
+					await connectTask.ConfigureAwait(false);
+					return tcpClient;
+				}
+			}
+		}
 	}
 }

--- a/src/cs/Ssh.Tcp/SshServer.cs
+++ b/src/cs/Ssh.Tcp/SshServer.cs
@@ -222,7 +222,15 @@ public class SshServer : IDisposable
 	{
 		if (disposing)
 		{
-			this.disposeCancellationSource.Cancel();
+			try
+			{
+				this.disposeCancellationSource.Cancel();
+			}
+			catch (ObjectDisposedException)
+			{
+				// The cancellation source was already disposed.
+			}
+			
 			this.disposeCancellationSource.Dispose();
 
 			foreach (SshServerSession serverSession in this.sessions.ToArray())

--- a/src/cs/Ssh.Tcp/SshSessionExtensions.cs
+++ b/src/cs/Ssh.Tcp/SshSessionExtensions.cs
@@ -67,11 +67,9 @@ public static class SshSessionExtensions
 	/// <param name="remotePort">The remote port to listen on, or 0 to choose an
 	/// available port. (The chosen port can then be obtained via the
 	/// <see cref="RemotePortConnector.RemotePort" /> property on the returned object.)</param>
-	/// <param name="localHost">The destination hostname or IP address for forwarded
-	/// connections, to be resolved on the local side. WARNING: Avoid using the hostname
-	/// `localhost` as the destination host; use `127.0.0.1` or `::1` instead. OpenSSH does not
-	/// recognize `localhost` as a valid destination host, and it can be slower anyway due to
-	/// a bug in .NET Core: https://github.com/dotnet/runtime/issues/31085 </param>
+	/// <param name="localHost">The destination hostname (such as `localhost`) or IP address for
+	/// forwarded connections, to be resolved on the local side. WARNING: OpenSSH does not
+	/// recognize `localhost` as a valid destination host.</param>
 	/// <param name="localPort">The destination port for forwarded connections.
 	/// (Must not be 0.)</param>
 	/// <param name="cancellation">Cancellation token for the request; note this cannot
@@ -149,11 +147,9 @@ public static class SshSessionExtensions
 	/// <param name="localPort">The local port number to lsiten on, or 0 to choose an
 	/// available port. (The chosen port can then be obtained via the
 	/// <see cref="LocalPortForwarder.LocalPort" /> property on the returned object.)</param>
-	/// <param name="remoteHost">The destination hostname or IP address for forwarded
-	/// connections, to be resolved on the remote side. WARNING: Avoid using the hostname
-	/// `localhost` as the destination host; use `127.0.0.1` or `::1` instead. OpenSSH does not
-	/// recognize `localhost` as a valid destination host, and it can be slower anyway due to
-	/// a bug in .NET Core: https://github.com/dotnet/runtime/issues/31085 </param>
+	/// <param name="remoteHost">The destination hostname (such as `localhost`) or IP address for
+	/// forwarded connections, to be resolved on the remote side. WARNING: OpenSSH does not
+	/// recognize `localhost` as a valid destination host.</param>
 	/// <param name="remotePort">The destination port for forwarded connections.
 	/// (Must not be 0.)</param>
 	/// <param name="cancellation">Cancellation token for the request; note this cannot

--- a/src/ts/ssh-tcp/services/remotePortForwarder.ts
+++ b/src/ts/ssh-tcp/services/remotePortForwarder.ts
@@ -92,6 +92,17 @@ export class RemotePortForwarder extends RemotePortConnector {
 		const socket = net.createConnection({
 			host: localHost,
 			port: localPort,
+
+			// This option enables connection attempts for multiple resolved IP addresses,
+			// aka "Happy Eyeballs" as described in https://datatracker.ietf.org/doc/html/rfc8305.
+			// Effectively this enables fast connections to either 127.0.0.1 or ::1 when 'localhost'
+			// is specified as the hostname. Note this option is available starting with Node.js
+			// v18.13 and is enabled by default starting with Node.js v20.0.
+			autoSelectFamily: true,
+
+			// Use the minimum supported connection attempt delay when connecting to 'localhost'.
+			// See https://nodejs.org/api/net.html#socketconnectoptions-connectlistener
+			autoSelectFamilyAttemptTimeout: localHost === 'localhost' ? 10 : 250,
 		});
 
 		const connectCompletion = new PromiseCompletionSource<void>();

--- a/test/cs/Ssh.Test/PortForwardingTests.cs
+++ b/test/cs/Ssh.Test/PortForwardingTests.cs
@@ -224,13 +224,12 @@ public class PortForwardingTests : IDisposable
 	[InlineData("0.0.0.0", "127.0.0.1", "localhost", "127.0.0.1")]
 	[InlineData("127.0.0.1", "127.0.0.1", "127.0.0.1", "127.0.0.1")]
 	[InlineData("127.0.0.1", "127.0.0.1", "localhost", "127.0.0.1")]
-#if !NETCOREAPP2_1 && !NET4
+	[InlineData("127.0.0.1", "127.0.0.1", "localhost", "::1")]
 	[InlineData("0.0.0.0", "::1", "::1", "::1")]
+	[InlineData("127.0.0.1", "::1", "::1", "::1")]
 	[InlineData("127.0.0.1", "::1", "localhost", "::1")]
-	[InlineData("::", "::1", "localhost", "::1")]
+	[InlineData("::", "::1", "::1", "::1")]
 	[InlineData("::1", "::1", "::1", "::1")]
-	[InlineData("::1", "::1", "localhost", "::1")]
-#endif
 	public async Task ForwardFromRemotePortReadWrite(
 		string remoteServerIPAddress,
 		string remoteClientIPAddress,
@@ -247,6 +246,11 @@ public class PortForwardingTests : IDisposable
 		Assert.NotNull(forwarder);
 
 		var localServer = new TcpListener(IPAddress.Parse(localServerIPAddress), TestPort2);
+		if (localServer.Server.AddressFamily == AddressFamily.InterNetworkV6)
+		{
+			localServer.Server.DualMode = false;
+		}
+
 		localServer.Start();
 		try
 		{
@@ -314,7 +318,7 @@ public class PortForwardingTests : IDisposable
 				readBuffer, 0, readBuffer.Length).WithTimeout(Timeout);
 			Assert.Equal(0, count);
 
-			// The channel will be closed asnynchronously.
+			// The channel will be closed asynchronously.
 			await TaskExtensions.WaitUntil(() => forwardingChannel.IsClosed).WithTimeout(Timeout);
 		}
 		finally
@@ -465,7 +469,7 @@ public class PortForwardingTests : IDisposable
 
 			await AssertSocketStreamClosedAsync(remoteEnd ? localStream : remoteStream);
 
-			// The channel will be closed asnynchronously.
+			// The channel will be closed asynchronously.
 			await TaskExtensions.WaitUntil(() => clientForwardingChannel.IsClosed)
 				.WithTimeout(Timeout);
 		}
@@ -562,7 +566,7 @@ public class PortForwardingTests : IDisposable
 		});
 		Assert.IsType<SocketException>(ioex.InnerException);
 
-		// The channel will be closed asnynchronously.
+		// The channel will be closed asynchronously.
 		await TaskExtensions.WaitUntil(() => forwardingChannel.IsClosed).WithTimeout(Timeout);
 	}
 
@@ -570,12 +574,12 @@ public class PortForwardingTests : IDisposable
 	[InlineData("0.0.0.0", "127.0.0.1", "localhost", "127.0.0.1")]
 	[InlineData("127.0.0.1", "127.0.0.1", "127.0.0.1", "127.0.0.1")]
 	[InlineData("127.0.0.1", "127.0.0.1", "localhost", "127.0.0.1")]
-#if !NETCOREAPP2_1 && !NET4
+	[InlineData("127.0.0.1", "127.0.0.1", "localhost", "::1")]
+	[InlineData("0.0.0.0", "::1", "::1", "::1")]
+	[InlineData("127.0.0.1", "::1", "::1", "::1")]
 	[InlineData("127.0.0.1", "::1", "localhost", "::1")]
+	[InlineData("::", "::1", "::1", "::1")]
 	[InlineData("::1", "::1", "::1", "::1")]
-	[InlineData("::1", "::1", "localhost", "::1")]
-	[InlineData("::", "::1", "localhost", "::1")]
-#endif
 	public async Task ForwardToRemotePortReadWrite(
 		string localServerIPAddress,
 		string localClientIPAddress,
@@ -598,6 +602,11 @@ public class PortForwardingTests : IDisposable
 		};
 
 		var remoteServer = new TcpListener(IPAddress.Parse(remoteServerIPAddress), TestPort2);
+		if (remoteServer.Server.AddressFamily == AddressFamily.InterNetworkV6)
+		{
+			remoteServer.Server.DualMode = false;
+		}
+
 		remoteServer.Start();
 		try
 		{
@@ -698,7 +707,7 @@ public class PortForwardingTests : IDisposable
 				readBuffer, 0, readBuffer.Length).WithTimeout(Timeout);
 			Assert.Equal(0, count);
 
-			// The channel will be closed asnynchronously.
+			// The channel will be closed asynchronously.
 			await TaskExtensions.WaitUntil(() => forwardingChannel.IsClosed).WithTimeout(Timeout);
 		}
 		finally
@@ -838,7 +847,7 @@ public class PortForwardingTests : IDisposable
 
 			await AssertSocketStreamClosedAsync(remoteEnd ? localStream : remoteStream);
 
-			// The channel will be closed asnynchronously.
+			// The channel will be closed asynchronously.
 			await TaskExtensions.WaitUntil(() => forwardingChannel.IsClosed).WithTimeout(Timeout);
 		}
 		finally

--- a/test/cs/Ssh.Test/PortForwardingTests.cs
+++ b/test/cs/Ssh.Test/PortForwardingTests.cs
@@ -225,11 +225,13 @@ public class PortForwardingTests : IDisposable
 	[InlineData("127.0.0.1", "127.0.0.1", "127.0.0.1", "127.0.0.1")]
 	[InlineData("127.0.0.1", "127.0.0.1", "localhost", "127.0.0.1")]
 	[InlineData("127.0.0.1", "127.0.0.1", "localhost", "::1")]
+#if !NET4
 	[InlineData("0.0.0.0", "::1", "::1", "::1")]
 	[InlineData("127.0.0.1", "::1", "::1", "::1")]
 	[InlineData("127.0.0.1", "::1", "localhost", "::1")]
 	[InlineData("::", "::1", "::1", "::1")]
 	[InlineData("::1", "::1", "::1", "::1")]
+#endif
 	public async Task ForwardFromRemotePortReadWrite(
 		string remoteServerIPAddress,
 		string remoteClientIPAddress,
@@ -575,11 +577,13 @@ public class PortForwardingTests : IDisposable
 	[InlineData("127.0.0.1", "127.0.0.1", "127.0.0.1", "127.0.0.1")]
 	[InlineData("127.0.0.1", "127.0.0.1", "localhost", "127.0.0.1")]
 	[InlineData("127.0.0.1", "127.0.0.1", "localhost", "::1")]
+#if !NET4
 	[InlineData("0.0.0.0", "::1", "::1", "::1")]
 	[InlineData("127.0.0.1", "::1", "::1", "::1")]
 	[InlineData("127.0.0.1", "::1", "localhost", "::1")]
 	[InlineData("::", "::1", "::1", "::1")]
 	[InlineData("::1", "::1", "::1", "::1")]
+#endif
 	public async Task ForwardToRemotePortReadWrite(
 		string localServerIPAddress,
 		string localClientIPAddress,

--- a/test/ts/ssh-test/portForwardingTests.ts
+++ b/test/ts/ssh-test/portForwardingTests.ts
@@ -45,10 +45,6 @@ const loopbackV6 = '::1';
 const anyV4 = '0.0.0.0';
 const anyV6 = '::';
 
-// Node.js >v16 resolves "localhost" to a v6 address instead of v4.
-const nodeMajorVersion = parseInt(process.versions.node.split('.')[0]);
-const loopback = nodeMajorVersion > 16 ? loopbackV6 : loopbackV4;
-
 class TestTcpListenerFactory implements TcpListenerFactory {
 	public constructor(public readonly localPortOverride: number) { }
 
@@ -228,7 +224,7 @@ export class PortForwardingTests {
 		remoteServerIPAddress: anyV4,
 		remoteClientIPAddress: loopbackV4,
 		localForwardHost: 'localhost',
-		localServerIPAddress: loopback,
+		localServerIPAddress: loopbackV4,
 	})
 	@params({
 		remoteServerIPAddress: loopbackV4,
@@ -240,7 +236,13 @@ export class PortForwardingTests {
 		remoteServerIPAddress: loopbackV4,
 		remoteClientIPAddress: loopbackV4,
 		localForwardHost: 'localhost',
-		localServerIPAddress: loopback,
+		localServerIPAddress: loopbackV4,
+	})
+	@params({
+		remoteServerIPAddress: loopbackV4,
+		remoteClientIPAddress: loopbackV4,
+		localForwardHost: 'localhost',
+		localServerIPAddress: loopbackV6,
 	})
 	@params({
 		remoteServerIPAddress: anyV4,
@@ -252,6 +254,12 @@ export class PortForwardingTests {
 		remoteServerIPAddress: loopbackV4,
 		remoteClientIPAddress: loopbackV6,
 		localForwardHost: loopbackV6,
+		localServerIPAddress: loopbackV6,
+	})
+	@params({
+		remoteServerIPAddress: loopbackV4,
+		remoteClientIPAddress: loopbackV6,
+		localForwardHost: 'localhost',
 		localServerIPAddress: loopbackV6,
 	})
 	@params({
@@ -600,7 +608,7 @@ export class PortForwardingTests {
 		localServerIPAddress: anyV4,
 		localClientIPAddress: loopbackV4,
 		remoteForwardHost: 'localhost',
-		remoteServerIPAddress: loopback,
+		remoteServerIPAddress: loopbackV4,
 	})
 	@params({
 		localServerIPAddress: loopbackV4,
@@ -612,7 +620,13 @@ export class PortForwardingTests {
 		localServerIPAddress: loopbackV4,
 		localClientIPAddress: loopbackV4,
 		remoteForwardHost: 'localhost',
-		remoteServerIPAddress: loopback,
+		remoteServerIPAddress: loopbackV4,
+	})
+	@params({
+		localServerIPAddress: loopbackV4,
+		localClientIPAddress: loopbackV4,
+		remoteForwardHost: 'localhost',
+		remoteServerIPAddress: loopbackV6,
 	})
 	@params({
 		localServerIPAddress: anyV4,
@@ -624,6 +638,12 @@ export class PortForwardingTests {
 		localServerIPAddress: loopbackV4,
 		localClientIPAddress: loopbackV6,
 		remoteForwardHost: loopbackV6,
+		remoteServerIPAddress: loopbackV6,
+	})
+	@params({
+		localServerIPAddress: loopbackV4,
+		localClientIPAddress: loopbackV6,
+		remoteForwardHost: 'localhost',
 		remoteServerIPAddress: loopbackV6,
 	})
 	@params({

--- a/test/ts/ssh-test/tcpUtils.ts
+++ b/test/ts/ssh-test/tcpUtils.ts
@@ -24,6 +24,7 @@ export function listenOnLocalPort(port: number, localIPAddress?: string): Promis
 	listener.listen({
 		host: localIPAddress ?? '127.0.0.1',
 		port,
+		ipv6Only: localIPAddress?.startsWith('::'),
 	});
 	return listenCompletion.promise;
 }


### PR DESCRIPTION
When forwarding a port, the server listening on that port might be bound to only IPv4 localhost (`127.0.0.1`), only IPv6 localhost (`::1`), or both. The SSH port-forwarding APIs allow the application to specify the host for forwarded connections as a specific IP address (such as `127.0.0.1` or `::1`) or as a hostname (such as `localhost`). If the application doesn't know whether the server is listening on IPv4 or IPv6, then it should be able to specify `localhost` to support either/both.

.NET TCP sockets on Windows do not support that very well: if the server is only listening on IPv4, there is **2-second delay** while the `::1` connection attempt times out before it falls back to successfully connecting to `127.0.0.1`. I consider that 2-second delay to be unacceptable performance for our SSH port-forwarding scenarios.

There is a conventional approach to handling this, defined in RFC 8305, but .NET has not implemented it yet. So this PR implements a very basic version of that algorithm, which works well at least for the IPv4/IPv6 localhost scenario. (It can be applied more generally to any hostnames that resolve to multiple IPv4 and/or IPv6 DNS records, but we're not concerned about that here.)

Node.js implemented a similar solution starting with v18. So I can just enable that option when creating the socket connection there.

I also created benchmarks for different combinations of IPv4/IPv6/localhost clients and hosts, to verify the performance of both .NET and Node.js SSH port-forwarding.