### PR TITLE
Handle `SSH_MSG_CHANNEL_EXTENDED_DATA` msg type

### DIFF
--- a/src/ts/ssh/events/sshExtendedDataEventArgs.ts
+++ b/src/ts/ssh/events/sshExtendedDataEventArgs.ts
@@ -1,0 +1,21 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//
+
+export enum SshExtendedDataType {
+	/**
+	 * The extended data type SSH_EXTENDED_DATA_STDERR has been defined for stderr data.
+	 */
+	STDERR = 1,
+}
+
+export class SshExtendedDataEventArgs {
+	public constructor(
+		public readonly dataTypeCode: SshExtendedDataType,
+		public readonly data: Buffer,
+	) {}
+
+	public toString() {
+		return `${SshExtendedDataType[this.dataTypeCode]}: ${this.data.toString()}`;
+	}
+}

--- a/src/ts/ssh/messages/connectionMessages.ts
+++ b/src/ts/ssh/messages/connectionMessages.ts
@@ -215,6 +215,34 @@ export class ChannelDataMessage extends ChannelMessage {
 	}
 }
 
+export class ChannelExtendedDataMessage extends ChannelMessage {
+	public get messageType(): number {
+		return 95;
+	}
+
+	public dataTypeCode?: number;
+	public data?: Buffer;
+
+	protected onRead(reader: SshDataReader): void {
+		super.onRead(reader);
+
+		this.dataTypeCode = reader.readUInt32();
+
+		this.data = reader.readBinary();
+	}
+
+	protected onWrite(writer: SshDataWriter): void {
+		super.onWrite(writer);
+
+		writer.writeUInt32(this.validateField(this.dataTypeCode, 'data type code'));
+		writer.writeBinary(this.validateField(this.data, 'data'));
+	}
+
+	public toString() {
+		return this.data ? formatBuffer(this.data, '') : '[0]';
+	}
+}
+
 export class ChannelEofMessage extends ChannelMessage {
 	public get messageType(): number {
 		return 96;
@@ -413,6 +441,7 @@ SshMessage.index.set(91, ChannelOpenConfirmationMessage);
 SshMessage.index.set(92, ChannelOpenFailureMessage);
 SshMessage.index.set(93, ChannelWindowAdjustMessage);
 SshMessage.index.set(94, ChannelDataMessage);
+SshMessage.index.set(95, ChannelExtendedDataMessage);
 SshMessage.index.set(96, ChannelEofMessage);
 SshMessage.index.set(97, ChannelCloseMessage);
 SshMessage.index.set(98, ChannelRequestMessage);

--- a/src/ts/ssh/messages/connectionMessages.ts
+++ b/src/ts/ssh/messages/connectionMessages.ts
@@ -239,7 +239,9 @@ export class ChannelExtendedDataMessage extends ChannelMessage {
 	}
 
 	public toString() {
-		return this.data ? formatBuffer(this.data, '') : '[0]';
+		return `${super.toString()} (dataTypeCode=${this.dataTypeCode}, data=${
+			this.data ? formatBuffer(this.data, '') : '[0]'
+		})`
 	}
 }
 

--- a/src/ts/ssh/services/connectionService.ts
+++ b/src/ts/ssh/services/connectionService.ts
@@ -28,6 +28,7 @@ import { ObjectDisposedError, SshChannelError, SshConnectionError } from '../err
 import { SshChannelOpeningEventArgs } from '../events/sshChannelOpeningEventArgs';
 import { serviceActivation } from './serviceActivation';
 import { TraceLevel, SshTraceEventIds } from '../trace';
+import { SshExtendedDataEventArgs } from '../events/sshExtendedDataEventArgs';
 
 interface PendingChannel {
 	openMessage: ChannelOpenMessage;
@@ -440,7 +441,7 @@ export class ConnectionService extends SshService {
 
 	private handleExtendedDataMessage(message: ChannelExtendedDataMessage): void {
 		const channel = this.tryGetChannelForMessage(message);
-		channel?.handleExtendedDataReceived(message.data!);
+		channel?.handleExtendedDataReceived(new SshExtendedDataEventArgs(message.dataTypeCode!, message.data!));
 	}
 
 	private handleAdjustWindowMessage(message: ChannelWindowAdjustMessage): void {

--- a/src/ts/ssh/services/connectionService.ts
+++ b/src/ts/ssh/services/connectionService.ts
@@ -17,6 +17,7 @@ import {
 	ChannelEofMessage,
 	SshChannelOpenFailureReason,
 	ChannelMessage,
+	ChannelExtendedDataMessage,
 } from '../messages/connectionMessages';
 import { SshSession } from '../sshSession';
 import { CancellationToken, Disposable } from 'vscode-jsonrpc';
@@ -177,6 +178,8 @@ export class ConnectionService extends SshService {
 	): void | Promise<void> {
 		if (message instanceof ChannelDataMessage) {
 			return this.handleDataMessage(message);
+		} else if (message instanceof ChannelExtendedDataMessage) {
+			return this.handleExtendedDataMessage(message);
 		} else if (message instanceof ChannelWindowAdjustMessage) {
 			return this.handleAdjustWindowMessage(message);
 		} else if (message instanceof ChannelEofMessage) {
@@ -433,6 +436,11 @@ export class ConnectionService extends SshService {
 	private handleDataMessage(message: ChannelDataMessage): void {
 		const channel = this.tryGetChannelForMessage(message);
 		channel?.handleDataReceived(message.data!);
+	}
+
+	private handleExtendedDataMessage(message: ChannelExtendedDataMessage): void {
+		const channel = this.tryGetChannelForMessage(message);
+		channel?.handleExtendedDataReceived(message.data!);
 	}
 
 	private handleAdjustWindowMessage(message: ChannelWindowAdjustMessage): void {

--- a/test/ts/ssh-test/pipeTests.ts
+++ b/test/ts/ssh-test/pipeTests.ts
@@ -187,6 +187,34 @@ export class PipeTests {
 	@test
 	@params({ fromTarget: true })
 	@params({ fromTarget: false })
+	@params.naming((p) => `pipeChannelSendExtendedData(fromTarget=${p.fromTarget})`)
+	public async pipeChannelSendExtendedData({ fromTarget }: { fromTarget: boolean }): Promise<void> {
+		await this.createSessions();
+		await connectSessionPair(this.clientSession1, this.serverSession1);
+		await connectSessionPair(this.clientSession2, this.serverSession2);
+		const [clientChannel1, serverChannel1] = await openChannel(
+			this.clientSession1,
+			this.serverSession1,
+		);
+		const [clientChannel2, serverChannel2] = await openChannel(
+			this.clientSession2,
+			this.serverSession2,
+		);
+		const pipePromise = serverChannel1.pipe(serverChannel2);
+
+		const testData = Buffer.from('test', 'utf8');
+		const dataCompletion = new PromiseCompletionSource<Buffer>();
+		(fromTarget ? clientChannel1 : clientChannel2).onExtendedDataReceived((data) => {
+			dataCompletion.resolve(data);
+		});
+		await (fromTarget ? clientChannel2 : clientChannel1).sendStderr(testData);
+		const receivedData = await withTimeout(dataCompletion.promise, timeoutMs);
+		assert(receivedData.equals(testData));
+	}
+
+	@test
+	@params({ fromTarget: true })
+	@params({ fromTarget: false })
 	@params.naming((p) => `pipeChannelSendSequence(fromTarget=${p.fromTarget})`)
 	public async pipeChannelSendSequence({ fromTarget }: { fromTarget: boolean }): Promise<void> {
 		await this.createSessions();


### PR DESCRIPTION
See [RFC](https://www.ietf.org/rfc/rfc4254.txt#:~:text=be%20passed%20with-,SSH_MSG_CHANNEL_EXTENDED_DATA,-messages%2C%20where%20a), search SSH_MSG_CHANNEL_EXTENDED_DATA

Fix https://github.com/microsoft/dev-tunnels-ssh/issues/68