### PR TITLE
Ignore invalid channel close messages

### DIFF
--- a/src/cs/Ssh/Services/ConnectionService.cs
+++ b/src/cs/Ssh/Services/ConnectionService.cs
@@ -469,7 +469,7 @@ internal class ConnectionService : SshService
 	private Task HandleMessageAsync(ChannelEofMessage message, CancellationToken cancellation)
 	{
 		cancellation.ThrowIfCancellationRequested();
-		var channel = TryGetChannelForMessage(message);
+		var channel = TryFindChannelById(message.RecipientChannel);
 		channel?.OnEof();
 		return Task.CompletedTask;
 	}
@@ -477,7 +477,7 @@ internal class ConnectionService : SshService
 	private Task HandleMessageAsync(ChannelCloseMessage message, CancellationToken cancellation)
 	{
 		cancellation.ThrowIfCancellationRequested();
-		var channel = TryGetChannelForMessage(message);
+		var channel = TryFindChannelById(message.RecipientChannel);
 		channel?.Close();
 		return Task.CompletedTask;
 	}
@@ -606,6 +606,10 @@ internal class ConnectionService : SshService
 		}
 	}
 
+	/// <summary>
+	/// Gets the channel object based on the message <see cref="ChannelMessage.RecipientChannel" />
+	/// property. Logs a warning if the channel was not found.
+	/// </summary>
 	private SshChannel? TryGetChannelForMessage(ChannelMessage channelMessage)
 	{
 		var channel = TryFindChannelById(channelMessage.RecipientChannel);

--- a/src/ts/ssh/services/connectionService.ts
+++ b/src/ts/ssh/services/connectionService.ts
@@ -314,7 +314,7 @@ export class ConnectionService extends SshService {
 	}
 
 	private handleCloseMessage(message: ChannelCloseMessage): void {
-		const channel = this.tryGetChannelForMessage(message);
+		const channel = this.findChannelById(message.recipientChannel!);
 		if (channel) {
 			channel.handleClose();
 		}
@@ -441,7 +441,7 @@ export class ConnectionService extends SshService {
 	}
 
 	private handleEofMessage(message: ChannelEofMessage): void {
-		const channel = this.tryGetChannelForMessage(message);
+		const channel = this.findChannelById(message.recipientChannel!);
 		channel?.handleEof();
 	}
 
@@ -461,6 +461,10 @@ export class ConnectionService extends SshService {
 		}
 	}
 
+	/**
+	 * Gets the channel object based on the message `recipientChannel` property.
+	 * Logs a warning if the channel was not found.
+	 */
 	private tryGetChannelForMessage(channelMessage: ChannelMessage): SshChannel | null {
 		const channel = this.findChannelById(channelMessage.recipientChannel!);
 		if (!channel) {


### PR DESCRIPTION
Fixes #66 

If a channel is closed near-concurrently on both sides, the close message could trigger a warning about invalid channel ID, since the recipient already closed the channel with that ID. This warning was common in application shutdown scenarios, but did not indicate any real problem. This change suppresses the warning for EOF and close messages, while retaining it for other channel message types like channel requests and channel data.