### PR TITLE
Fix extended-data exports

### DIFF
--- a/src/ts/ssh/index.ts
+++ b/src/ts/ssh/index.ts
@@ -24,6 +24,7 @@ export { SshRequestEventArgs } from './events/sshRequestEventArgs';
 export { SshChannelOpeningEventArgs } from './events/sshChannelOpeningEventArgs';
 export { SshSessionClosedEventArgs } from './events/sshSessionClosedEventArgs';
 export { SshChannelClosedEventArgs } from './events/sshChannelClosedEventArgs';
+export { SshExtendedDataType, SshExtendedDataEventArgs } from './events/sshExtendedDataEventArgs';
 
 export { SshMessage } from './messages/sshMessage';
 export {

--- a/test/ts/ssh-test/pipeTests.ts
+++ b/test/ts/ssh-test/pipeTests.ts
@@ -22,12 +22,12 @@ import {
 	SshDataReader,
 	SshDataWriter,
 	SshDisconnectReason,
+	SshExtendedDataType,
 	SshServerSession,
 	SshSessionClosedEventArgs,
 } from '@microsoft/dev-tunnels-ssh';
 import { connectSessionPair, createSessionPair, openChannel } from './sessionPair';
 import { expectError, until, withTimeout } from './promiseUtils';
-import { SshExtendedDataType } from 'src/ts/ssh/events/sshExtendedDataEventArgs';
 
 const timeoutMs = 5000;
 


### PR DESCRIPTION
Fix build break from #68.

It wasn't caught by the PR build because there is an unrelated problem with reporting test results for PRs from external contributors.