### PR TITLE
Implement SSH interactive auth method

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ The following RFCs define the SSH protocol:
  - [RFC 4252 - SSH Authentication Protocol](https://tools.ietf.org/html/rfc4252)
  - [RFC 4253 - SSH Transport Layer Protocol](https://tools.ietf.org/html/rfc4253)
  - [RFC 4254 - SSH Connection Protocol](https://tools.ietf.org/html/rfc4254)
+ - [RFC 4256 - Generic Message Exchange Authentication for SSH](https://tools.ietf.org/html/rfc4256)
  - [RFC 4716 - SSH Public Key File Format](https://tools.ietf.org/html/rfc4716)
  - [RFC 5647 - AES GCM for the SSH Protocol](https://tools.ietf.org/html/rfc5647)
  - [RFC 5656 - EC Algorithm Integration in SSH](https://tools.ietf.org/html/rfc5656)

--- a/src/cs/Ssh.Tcp/SshServer.cs
+++ b/src/cs/Ssh.Tcp/SshServer.cs
@@ -53,7 +53,7 @@ public class SshServer : IDisposable
 	public event EventHandler<SshRequestEventArgs<SessionRequestMessage>>? SessionRequest;
 	public event EventHandler<SshChannelOpeningEventArgs>? ChannelOpening;
 	public event EventHandler<SshRequestEventArgs<ChannelRequestMessage>>? ChannelRequest;
-	public event EventHandler<Exception>? ExceptionRasied;
+	public event EventHandler<Exception>? ExceptionRaised;
 
 	public SshServerCredentials Credentials { get; set; } = new SshServerCredentials();
 
@@ -165,20 +165,20 @@ public class SshServer : IDisposable
 						catch (SshConnectionException ex)
 						{
 							await session.CloseAsync(ex.DisconnectReason, ex).ConfigureAwait(false);
-							ExceptionRasied?.Invoke(this, ex);
+							ExceptionRaised?.Invoke(this, ex);
 						}
 						catch (Exception ex)
 						{
 							await session.CloseAsync(SshDisconnectReason.ProtocolError, ex)
 							.ConfigureAwait(false);
-							ExceptionRasied?.Invoke(this, ex);
+							ExceptionRaised?.Invoke(this, ex);
 						}
 					});
 				}
 			}
 			catch (Exception ex)
 			{
-				ExceptionRasied?.Invoke(this, ex);
+				ExceptionRaised?.Invoke(this, ex);
 			}
 			finally
 			{

--- a/src/cs/Ssh/Events/SshAuthenticatingEventArgs.cs
+++ b/src/cs/Ssh/Events/SshAuthenticatingEventArgs.cs
@@ -1,11 +1,13 @@
 // Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.DevTunnels.Ssh.Algorithms;
+using Microsoft.DevTunnels.Ssh.Messages;
 
 namespace Microsoft.DevTunnels.Ssh.Events;
 
@@ -81,6 +83,16 @@ public enum SshAuthenticationType
 	ClientPublicKey = 4,
 
 	/// <summary>
+	/// The client is attempting to authenticate with interactive prompts.
+	/// </summary>
+	/// <remarks>
+	/// This event is raised by an <see cref="SshServerSession"/> when the client requests
+	/// authentication using the "keyboard-interactive" method. The event may be raised multiple
+	/// times for the same client to facilitate multi-step authentication.
+	/// </remarks>
+	ClientInteractive = 5,
+
+	/// <summary>
 	/// The server is attempting to authenticate with a public key credential.
 	/// </summary>
 	/// <remarks>
@@ -106,7 +118,7 @@ public enum SshAuthenticationType
 /// After validating the credentials, the event handler must set the
 /// <see cref="AuthenticationTask" /> property to a task that resolves to a principal object
 /// to indicate successful authentication. That principal will then be associated with the
-/// sesssion as the <see cref="SshSession.Principal" /> property.
+/// session as the <see cref="SshSession.Principal" /> property.
 /// </remarks>
 [DebuggerDisplay("{ToString(),nq}")]
 [DebuggerStepThrough]
@@ -165,6 +177,26 @@ public class SshAuthenticatingEventArgs
 		Cancellation = cancellation;
 	}
 
+	public SshAuthenticatingEventArgs(
+		SshAuthenticationType authenticationType,
+		string? username,
+		AuthenticationInfoRequestMessage? infoRequest,
+		AuthenticationInfoResponseMessage? infoResponse,
+		CancellationToken cancellation = default)
+	{
+		if (authenticationType != SshAuthenticationType.ClientInteractive)
+		{
+			throw new ArgumentException(
+				$"Authentication type {SshAuthenticationType.ClientInteractive} expected.");
+		}
+
+		AuthenticationType = authenticationType;
+		Username = username;
+		InfoRequest = infoRequest;
+		InfoResponse = infoResponse;
+		Cancellation = cancellation;
+	}
+
 	/// <summary>
 	/// Indicates the type of authentication being requested, which determines which credential
 	/// properties are valid.
@@ -200,6 +232,22 @@ public class SshAuthenticatingEventArgs
 	public string? ClientUsername { get; }
 
 	/// <summary>
+	/// Gets or sets a request more information for interactive authentication.
+	/// </summary>
+	/// <remarks>
+	/// The server may set this property when handling an interactive authenticating event to prompt
+	/// for information/credentials. The client may read this property when handling an interactive
+	/// authenticating event to determine what prompts to show and what information is requested.
+	/// </remarks>
+	public AuthenticationInfoRequestMessage? InfoRequest { get; set; }
+
+	/// <summary>
+	/// Gets or sets the client's responses to interactive prompts; valid only for interactive
+	/// authentication when information was previously requested via <see cref="InfoRequest"/>.
+	/// </summary>
+	public AuthenticationInfoResponseMessage? InfoResponse { get; set; }
+
+	/// <summary>
 	/// Gets a token that is cancelled if the session ends before the authentication handler
 	/// completes.
 	/// </summary>
@@ -218,7 +266,15 @@ public class SshAuthenticatingEventArgs
 
 	public override string ToString()
 	{
-		if (Username != null)
+		if (InfoRequest != null)
+		{
+			return $"Info request: {InfoRequest.Name}";
+		}
+		else if (InfoResponse != null)
+		{
+			return $"Username: {Username}, Info response";
+		}
+		else if (Username != null)
 		{
 			return $"Username: {Username}, Key: {PublicKey?.KeyAlgorithmName ?? "password"}";
 		}

--- a/src/cs/Ssh/Events/SshAuthenticatingEventArgs.cs
+++ b/src/cs/Ssh/Events/SshAuthenticatingEventArgs.cs
@@ -232,7 +232,7 @@ public class SshAuthenticatingEventArgs
 	public string? ClientUsername { get; }
 
 	/// <summary>
-	/// Gets or sets a request more information for interactive authentication.
+	/// Gets or sets a request for more information for interactive authentication.
 	/// </summary>
 	/// <remarks>
 	/// The server may set this property when handling an interactive authenticating event to prompt

--- a/src/cs/Ssh/IO/SshProtocol.cs
+++ b/src/cs/Ssh/IO/SshProtocol.cs
@@ -97,6 +97,8 @@ internal class SshProtocol : IDisposable
 
 	internal SshSessionAlgorithms? Algorithms { get; private set; }
 
+	internal string? MessageContext { get; set; }
+
 	internal bool OutgoingMessagesHaveLatencyInfo { get; set; }
 	internal bool IncomingMessagesHaveLatencyInfo { get; set; }
 	internal bool OutgoingMessagesHaveReconnectInfo { get; set; }
@@ -505,7 +507,7 @@ internal class SshProtocol : IDisposable
 		}
 
 		var messageType = payload[0];
-		SshMessage? message = SshMessage.TryCreate(this.config, messageType);
+		SshMessage? message = SshMessage.TryCreate(this.config, messageType, MessageContext);
 		if (message != null)
 		{
 			var reader = new SshDataReader(payload);

--- a/src/cs/Ssh/Messages/Authentication/AuthenticationInfoRequestMessage.cs
+++ b/src/cs/Ssh/Messages/Authentication/AuthenticationInfoRequestMessage.cs
@@ -1,0 +1,81 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.DevTunnels.Ssh.IO;
+
+namespace Microsoft.DevTunnels.Ssh.Messages;
+
+[SshMessage("SSH_MSG_USERAUTH_INFO_REQUEST", MessageNumber)]
+public class AuthenticationInfoRequestMessage : AuthenticationMessage
+{
+	public const byte MessageNumber = 60;
+
+	public override byte MessageType => MessageNumber;
+
+	public string Name { get; private set; }
+	public string? Instruction { get; set; }
+	public string? Language { get; set; }
+	public IList<(string Prompt, bool Echo)> Prompts { get; private set; }
+
+	public AuthenticationInfoRequestMessage() : this(string.Empty)
+	{
+	}
+
+	public AuthenticationInfoRequestMessage(string name)
+	{
+		Name = name;
+		Prompts = new List<(string, bool)>();
+	}
+
+	public void AddPrompt(string prompt, bool echo)
+	{
+		Prompts.Add((prompt, echo));
+	}
+
+	protected override void OnWrite(ref SshDataWriter writer)
+	{
+		writer.Write(Name ?? string.Empty, Encoding.UTF8);
+		writer.Write(Instruction ?? string.Empty, Encoding.UTF8);
+		writer.Write(Language ?? string.Empty, Encoding.ASCII);
+		writer.Write((uint)Prompts.Count);
+
+		foreach (var (prompt, _) in Prompts)
+		{
+			writer.Write(prompt ?? string.Empty, Encoding.UTF8);
+		}
+
+		foreach (var (_, echo) in Prompts)
+		{
+			writer.Write(echo);
+		}
+	}
+
+	protected override void OnRead(ref SshDataReader reader)
+	{
+		Name = reader.ReadString(Encoding.UTF8);
+		Instruction = reader.ReadString(Encoding.UTF8);
+		Language = reader.ReadString(Encoding.ASCII);
+
+		Prompts.Clear();
+		int promptsCount = (int)reader.ReadUInt32();
+
+		string[] promptStrings = new string[promptsCount];
+		for (int i = 0; i < promptsCount; i++)
+		{
+			promptStrings[i] = reader.ReadString(Encoding.UTF8);
+		}
+
+		for (int i = 0; i < promptsCount; i++)
+		{
+			bool echo = reader.ReadBoolean();
+			Prompts.Add((promptStrings[i], echo));
+		}
+	}
+
+	public override string ToString()
+	{
+		return $"{base.ToString()} \"{Name}\"";
+	}
+}

--- a/src/cs/Ssh/Messages/Authentication/AuthenticationInfoResponseMessage.cs
+++ b/src/cs/Ssh/Messages/Authentication/AuthenticationInfoResponseMessage.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.DevTunnels.Ssh.IO;
+
+namespace Microsoft.DevTunnels.Ssh.Messages;
+
+[SshMessage("SSH_MSG_USERAUTH_INFO_RESPONSE", MessageNumber)]
+public class AuthenticationInfoResponseMessage : AuthenticationMessage
+{
+	internal const byte MessageNumber = 61;
+
+	public IList<string> Responses { get; private set; }
+
+	public override byte MessageType => MessageNumber;
+
+	public AuthenticationInfoResponseMessage()
+	{
+		Responses = new List<string>();
+	}
+
+	protected override void OnWrite(ref SshDataWriter writer)
+	{
+		writer.Write((uint)Responses.Count);
+		foreach (string response in Responses)
+		{
+			writer.Write(response ?? string.Empty, Encoding.UTF8);
+		}
+	}
+
+	protected override void OnRead(ref SshDataReader reader)
+	{
+		Responses.Clear();
+		int responseCount = (int)reader.ReadUInt32();
+		for (int i = 0; i < responseCount; i++)
+		{
+			Responses.Add(reader.ReadString(Encoding.UTF8));
+		}
+	}
+}

--- a/src/cs/Ssh/Messages/Authentication/AuthenticationMethods.cs
+++ b/src/cs/Ssh/Messages/Authentication/AuthenticationMethods.cs
@@ -2,10 +2,15 @@
 
 namespace Microsoft.DevTunnels.Ssh.Messages;
 
-internal static class AuthenticationMethods
+/// <summary>
+/// Defines constants for standard authentication methods.
+/// </summary>
+/// <seealso cref="SshSessionConfiguration.AuthenticationMethods" />
+public static class AuthenticationMethods
 {
 	public const string None = "none";
 	public const string PublicKey = "publickey";
 	public const string Password = "password";
 	public const string HostBased = "hostbased";
+	public const string KeyboardInteractive = "keyboard-interactive";
 }

--- a/src/cs/Ssh/Messages/SshMessage.cs
+++ b/src/cs/Ssh/Messages/SshMessage.cs
@@ -10,14 +10,22 @@ namespace Microsoft.DevTunnels.Ssh.Messages;
 public abstract class SshMessage
 {
 	/// <summary>
-	/// Tries to create a message with the given message type code.
+	/// Tries to create a message with the given message type code and optional context.
 	/// </summary>
 	/// <returns>The constructed message object, or null if not a known message type.</returns>
-	public static SshMessage? TryCreate(SshSessionConfiguration config, byte messageType)
+	public static SshMessage? TryCreate(
+		SshSessionConfiguration config,
+		byte messageType,
+		string? messageContext)
 	{
 		if (config == null) throw new ArgumentNullException(nameof(config));
 
 		if (config.Messages.TryGetValue(messageType, out var type))
+		{
+			return (SshMessage)Activator.CreateInstance(type)!;
+		}
+		else if (messageContext != null &&
+			config.ContextualMessages.TryGetValue((messageType, messageContext), out type))
 		{
 			return (SshMessage)Activator.CreateInstance(type)!;
 		}

--- a/src/cs/Ssh/Services/AuthenticationService.cs
+++ b/src/cs/Ssh/Services/AuthenticationService.cs
@@ -25,14 +25,9 @@ internal class AuthenticationService : SshService
 {
 	public const string Name = "ssh-userauth";
 
-	private static readonly string[] SupportedAuthMethods = new[]
-	{
-		AuthenticationMethods.PublicKey,
-		AuthenticationMethods.Password,
-		AuthenticationMethods.HostBased,
-	};
-
-	private Queue<Func<CancellationToken, Task>>? clientAuthenticationMethods;
+	private Queue<(string Method, Func<CancellationToken, Task> Handler)>?
+		clientAuthenticationMethods;
+	private AuthenticationRequestMessage? currentRequestMessage;
 	private int authenticationFailureCount = 0;
 	private readonly CancellationTokenSource disposeCancellationSource =
 		new CancellationTokenSource();
@@ -59,7 +54,9 @@ internal class AuthenticationService : SshService
 			AuthenticationRequestMessage m => HandleMessageAsync(m, cancellation),
 			AuthenticationSuccessMessage m => HandleMessageAsync(m, cancellation),
 			AuthenticationFailureMessage m => HandleMessageAsync(m, cancellation),
-			PublicKeyOkMessage => Task.CompletedTask,
+			AuthenticationInfoRequestMessage m => HandleMessageAsync(m, cancellation),
+			AuthenticationInfoResponseMessage m => HandleMessageAsync(m, cancellation),
+			PublicKeyOkMessage m => Task.CompletedTask,
 			_ => Task.CompletedTask, // Ignore unrecognized authentication messages.
 		};
 	}
@@ -67,7 +64,16 @@ internal class AuthenticationService : SshService
 	private async Task HandleMessageAsync(
 		AuthenticationRequestMessage message, CancellationToken cancellation)
 	{
-		switch (message.MethodName)
+		SetCurrentRequest(message);
+
+		var methodName = message.MethodName!;
+		if (!Session.Config.AuthenticationMethods.Contains(methodName))
+		{
+			// A failure message with enabled auth methods will be sent below.
+			methodName = null;
+		}
+
+		switch (methodName)
 		{
 			case AuthenticationMethods.HostBased:
 			case AuthenticationMethods.PublicKey:
@@ -78,21 +84,43 @@ internal class AuthenticationService : SshService
 				await HandleMessageAsync(message.ConvertTo<PasswordRequestMessage>(), cancellation)
 					.ConfigureAwait(false);
 				break;
+			case AuthenticationMethods.KeyboardInteractive:
+				await BeginInteractiveAuthenticationAsync(message, cancellation)
+					.ConfigureAwait(false);
+				break;
 			case AuthenticationMethods.None:
 				await HandleAuthenticatingAsync(
-					message,
-					new SshAuthenticatingEventArgs(
-						SshAuthenticationType.ClientNone, message.Username),
+					new SshAuthenticatingEventArgs(SshAuthenticationType.ClientNone, message.Username),
 					cancellation).ConfigureAwait(false);
 				break;
 			default:
+				SetCurrentRequest(null);
 				await Session.SendMessageAsync(
 					new AuthenticationFailureMessage
 					{
-						MethodNames = SupportedAuthMethods,
+						MethodNames = Session.Config.AuthenticationMethods.ToArray(),
 					},
 					cancellation).ConfigureAwait(false);
 				break;
+		}
+	}
+
+	/// <summary>
+	/// Sets the current authentication request state for the session, which affects how following
+	/// authentication messages are interpreted.
+	/// </summary>
+	/// <param name="message">The message that began the current authentication request, or null
+	/// to clear the state because the current request completed with success or failure.</param>
+	private void SetCurrentRequest(AuthenticationRequestMessage? message)
+	{
+		this.currentRequestMessage = message;
+
+		// Setting the message context on the protocol allows it to deserialize message numbers
+		// for which the message type depends on the current authentication method.
+		var protocol = Session.Protocol;
+		if (protocol != null)
+		{
+			protocol.MessageContext = message?.MethodName;
 		}
 	}
 
@@ -161,7 +189,7 @@ internal class AuthenticationService : SshService
 
 		// Raise an Authenticating event that allows handlers to do additional verification
 		// of the client's username and public key. Then send a response.
-		await HandleAuthenticatingAsync(message, args, cancellation).ConfigureAwait(false);
+		await HandleAuthenticatingAsync(args, cancellation).ConfigureAwait(false);
 	}
 
 	private async Task HandleMessageAsync(
@@ -171,17 +199,62 @@ internal class AuthenticationService : SshService
 		// of the client's username and password.
 		var args = new SshAuthenticatingEventArgs(
 			SshAuthenticationType.ClientPassword,
-			username: message.Username!,
+			username: message.Username,
 			password: message.Password ?? string.Empty);
-		await HandleAuthenticatingAsync(message, args, cancellation)
-			.ConfigureAwait(false);
+		await HandleAuthenticatingAsync(args, cancellation).ConfigureAwait(false);
+	}
+
+	private async Task BeginInteractiveAuthenticationAsync(
+		AuthenticationRequestMessage message, CancellationToken cancellation)
+	{
+		// Raise an Authenticating event that allows the server to interactively prompt for
+		// information from the client.
+		var args = new SshAuthenticatingEventArgs(
+			SshAuthenticationType.ClientInteractive,
+			username: message.Username,
+			infoRequest: null,
+			infoResponse: null);
+		await HandleAuthenticatingAsync(args, cancellation).ConfigureAwait(false);
+	}
+
+	private async Task HandleMessageAsync(
+		AuthenticationInfoRequestMessage message, CancellationToken cancellation)
+	{
+		// Raise an Authenticating event that allows the client to respond to interactive prompts
+		// and provide requested information to the server.
+		var args = new SshAuthenticatingEventArgs(
+			SshAuthenticationType.ClientInteractive,
+			username: null,
+			infoRequest: message,
+			infoResponse: null);
+		await HandleAuthenticatingAsync(args, cancellation).ConfigureAwait(false);
+	}
+
+	private async Task HandleMessageAsync(
+		AuthenticationInfoResponseMessage message, CancellationToken cancellation)
+	{
+		// Raise an Authenticating event that allows the server to process the client's responses
+		// to interactive prompts, and request further info if necessary.
+		var args = new SshAuthenticatingEventArgs(
+			SshAuthenticationType.ClientInteractive,
+			this.currentRequestMessage?.Username,
+			infoRequest: null,
+			infoResponse: message,
+			cancellation);
+		await HandleAuthenticatingAsync(args, cancellation).ConfigureAwait(false);
 	}
 
 	private async Task HandleAuthenticatingAsync(
-		AuthenticationRequestMessage requestMessage,
 		SshAuthenticatingEventArgs args,
 		CancellationToken cancellation)
 	{
+		if (this.currentRequestMessage == null)
+		{
+			throw new SshConnectionException(
+				$"No current authentication request.",
+				SshDisconnectReason.ProtocolError);
+		}
+
 		args.Cancellation = this.disposeCancellationSource.Token;
 
 		ClaimsPrincipal? authenticatedPrincipal;
@@ -203,21 +276,24 @@ internal class AuthenticationService : SshService
 		{
 			if (args.AuthenticationType == SshAuthenticationType.ClientPublicKeyQuery)
 			{
-				var publicKeyRequest = (PublicKeyRequestMessage)requestMessage;
+				var publicKeyRequest = (PublicKeyRequestMessage)this.currentRequestMessage;
 				var okMessage = new PublicKeyOkMessage
 				{
 					KeyAlgorithmName = publicKeyRequest.KeyAlgorithmName,
 					PublicKey = publicKeyRequest.PublicKey,
 				};
+
+				SetCurrentRequest(null);
 				await Session.SendMessageAsync(okMessage, cancellation).ConfigureAwait(false);
 			}
 			else
 			{
 				Session.Principal = authenticatedPrincipal;
 
-				if (!string.IsNullOrEmpty(requestMessage.ServiceName))
+				var serviceName = this.currentRequestMessage.ServiceName;
+				if (!string.IsNullOrEmpty(serviceName))
 				{
-					Session.ActivateService(requestMessage.ServiceName!);
+					Session.ActivateService(serviceName!);
 				}
 
 				Session.Trace.TraceEvent(
@@ -225,14 +301,28 @@ internal class AuthenticationService : SshService
 					SshTraceEventIds.SessionAuthenticated,
 					$"{args.AuthenticationType} authentication succeeded.");
 
+				SetCurrentRequest(null);
 				await Session.SendMessageAsync(new AuthenticationSuccessMessage(), cancellation)
 					.ConfigureAwait(false);
 
 				(Session as SshServerSession)?.HandleClientAuthenticated();
 			}
 		}
+		else if (args.AuthenticationType == SshAuthenticationType.ClientInteractive &&
+			Session is SshServerSession && args.InfoRequest != null)
+		{
+			// Server authenticating event-handler supplied an info request.
+			await Session.SendMessageAsync(args.InfoRequest, cancellation).ConfigureAwait(false);
+		}
+		else if (args.AuthenticationType == SshAuthenticationType.ClientInteractive &&
+			Session is SshClientSession && args.InfoResponse != null)
+		{
+			// Client authenticating event-handler supplied an info response.
+			await Session.SendMessageAsync(args.InfoResponse, cancellation).ConfigureAwait(false);
+		}
 		else
 		{
+			SetCurrentRequest(null);
 			await HandleAuthenticationFailureAsync(
 				$"{args.AuthenticationType} authentication failed.",
 				cancellation).ConfigureAwait(false);
@@ -256,7 +346,7 @@ internal class AuthenticationService : SshService
 		await Session.SendMessageAsync(
 			new AuthenticationFailureMessage
 			{
-				MethodNames = SupportedAuthMethods,
+				MethodNames = Session.Config.AuthenticationMethods.ToArray(),
 			},
 			cancellation).ConfigureAwait(false);
 
@@ -273,89 +363,128 @@ internal class AuthenticationService : SshService
 		SshClientCredentials credentials,
 		CancellationToken cancellation)
 	{
-		this.clientAuthenticationMethods = new Queue<Func<CancellationToken, Task>>();
+		this.clientAuthenticationMethods = new Queue<(string, Func<CancellationToken, Task>)>();
+		var configuredMethods = Session.Config.AuthenticationMethods;
 
-		foreach (var publicKey in credentials.PublicKeys ?? Enumerable.Empty<IKeyPair>())
+		if (configuredMethods.Contains(AuthenticationMethods.PublicKey))
 		{
-			if (publicKey == null)
+			foreach (var publicKey in credentials.PublicKeys ?? Enumerable.Empty<IKeyPair>())
 			{
-				continue;
-			}
-
-			var username = credentials.Username ?? string.Empty;
-			IKeyPair? privateKey = publicKey;
-			var privateKeyProvider = credentials.PrivateKeyProvider;
-
-			this.clientAuthenticationMethods.Enqueue(async (cancellation) =>
-			{
-				if (!privateKey.HasPrivateKey)
+				if (publicKey == null)
 				{
-					if (privateKeyProvider == null)
+					continue;
+				}
+
+				var username = credentials.Username ?? string.Empty;
+				IKeyPair? privateKey = publicKey;
+				var privateKeyProvider = credentials.PrivateKeyProvider;
+
+				this.clientAuthenticationMethods.Enqueue(
+					(AuthenticationMethods.PublicKey, async (cancellation) =>
 					{
-						throw new InvalidOperationException("A private key provider is required.");
-					}
+						if (!privateKey.HasPrivateKey)
+						{
+							if (privateKeyProvider == null)
+							{
+								throw new InvalidOperationException("A private key provider is required.");
+							}
 
-					privateKey = await privateKeyProvider(privateKey, cancellation)
-						.ConfigureAwait(false);
-				}
+							privateKey = await privateKeyProvider(privateKey, cancellation)
+								.ConfigureAwait(false);
+						}
 
-				if (privateKey != null)
-				{
-					await RequestAuthenticationAsync(username, privateKey, cancellation)
-						.ConfigureAwait(false);
-				}
-				else
-				{
-					await Session.CloseAsync(SshDisconnectReason.AuthCancelledByUser)
-						.ConfigureAwait(false);
-				}
-			});
+						if (privateKey != null)
+						{
+							await RequestAuthenticationAsync(username, privateKey, cancellation)
+								.ConfigureAwait(false);
+						}
+						else
+						{
+							await Session.CloseAsync(SshDisconnectReason.AuthCancelledByUser)
+								.ConfigureAwait(false);
+						}
+					}));
+			}
 		}
 
-		var passwordCredentialProvider = credentials.PasswordProvider;
-		if (passwordCredentialProvider != null)
+		if (configuredMethods.Contains(AuthenticationMethods.Password))
 		{
-			this.clientAuthenticationMethods.Enqueue(async (cancellation) =>
+			var passwordCredentialProvider = credentials.PasswordProvider;
+			if (passwordCredentialProvider != null)
 			{
-				var passwordCredentialTask = passwordCredentialProvider(cancellation);
-				var passwordCredential = passwordCredentialTask != null
-					? await passwordCredentialTask.ConfigureAwait(false) : null;
-				if (passwordCredential != null)
-				{
-					await RequestAuthenticationAsync(
-						passwordCredential.Value.Item1 ?? string.Empty,
-						passwordCredential.Value.Item2,
-						cancellation).ConfigureAwait(false);
-				}
-				else
-				{
-					await Session.CloseAsync(SshDisconnectReason.AuthCancelledByUser)
-						.ConfigureAwait(false);
-				}
-			});
-		}
-		else if (credentials.Password != null)
-		{
-			var username = credentials.Username ?? string.Empty;
-			var password = credentials.Password;
-			this.clientAuthenticationMethods.Enqueue(async (cancellation) =>
+				this.clientAuthenticationMethods.Enqueue(
+					(AuthenticationMethods.Password, async (cancellation) =>
+					{
+						var passwordCredentialTask = passwordCredentialProvider(cancellation);
+						var passwordCredential = passwordCredentialTask != null
+							? await passwordCredentialTask.ConfigureAwait(false) : null;
+						if (passwordCredential != null)
+						{
+							await RequestAuthenticationAsync(
+								passwordCredential.Value.Item1 ?? string.Empty,
+								passwordCredential.Value.Item2,
+								cancellation).ConfigureAwait(false);
+						}
+						else
+						{
+							await Session.CloseAsync(SshDisconnectReason.AuthCancelledByUser)
+								.ConfigureAwait(false);
+						}
+					}));
+			}
+			else if (credentials.Password != null)
 			{
-				await RequestAuthenticationAsync(username, password, cancellation)
-					.ConfigureAwait(false);
-			});
+				var username = credentials.Username ?? string.Empty;
+				var password = credentials.Password;
+				this.clientAuthenticationMethods.Enqueue(
+					(AuthenticationMethods.Password, async (cancellation) =>
+					{
+						await RequestAuthenticationAsync(username, password, cancellation)
+							.ConfigureAwait(false);
+					}));
+			}
 		}
 
+		// Only add None or Interactive methods if no client credentials were supplied.
 		if (this.clientAuthenticationMethods.Count == 0)
 		{
 			var username = credentials.Username ?? string.Empty;
-			this.clientAuthenticationMethods.Enqueue(async (cancellation) =>
+
+			if (configuredMethods.Contains(AuthenticationMethods.None))
 			{
-				await RequestAuthenticationAsync(username, cancellation).ConfigureAwait(false);
-			});
+				this.clientAuthenticationMethods.Enqueue(
+					(AuthenticationMethods.None, async (cancellation) =>
+					{
+						await RequestAuthenticationAsync(username, cancellation).ConfigureAwait(false);
+					}));
+			}
+
+			if (configuredMethods.Contains(AuthenticationMethods.KeyboardInteractive))
+			{
+				this.clientAuthenticationMethods.Enqueue(
+					(AuthenticationMethods.KeyboardInteractive, async (cancellation) =>
+					{
+						await RequestInteractiveAuthenticationAsync(username, cancellation)
+							.ConfigureAwait(false);
+					}));
+			}
+
+			if (this.clientAuthenticationMethods.Count == 0)
+			{
+				throw new InvalidOperationException(
+					$"Could not prepare request for authentication method(s): " +
+					string.Join(", ", configuredMethods) +
+					". Supply client credentials or enable None or Interactive authentication methods.");
+			}
 		}
 
+		// Auth request messages all include a request the for the server to activate the connection
+		// service . Go ahead and activate it on the client side too; if authentication fails then
+		// a following channel open request will fail anyway.
+		Session.ActivateService<ConnectionService>();
+
 		var firstAuthMethod = this.clientAuthenticationMethods.Dequeue();
-		await firstAuthMethod(cancellation).ConfigureAwait(false);
+		await firstAuthMethod.Handler(cancellation).ConfigureAwait(false);
 	}
 
 	private async Task RequestAuthenticationAsync(
@@ -366,11 +495,8 @@ internal class AuthenticationService : SshService
 			ConnectionService.Name,
 			AuthenticationMethods.None,
 			username);
+		SetCurrentRequest(authMessage);
 		await Session.SendMessageAsync(authMessage, cancellation).ConfigureAwait(false);
-
-		// Assume the included service request succeeds, without waiting for an auth success
-		// message. If not, a following channel open request will fail anyway.
-		Session.ActivateService<ConnectionService>();
 	}
 
 	private async Task RequestAuthenticationAsync(
@@ -389,15 +515,8 @@ internal class AuthenticationService : SshService
 		var authMessage = new PublicKeyRequestMessage(
 			ConnectionService.Name, username, algorithm, key);
 		authMessage.Signature = CreateAuthenticationSignature(authMessage, algorithm, key);
+		SetCurrentRequest(authMessage);
 		await Session.SendMessageAsync(authMessage, cancellation).ConfigureAwait(false);
-
-		if (this.clientAuthenticationMethods!.Count == 0)
-		{
-			// There are no remaining auth methods. Assume the service request
-			// included here succeeds, without waiting for an auth success message
-			// If not, a following channel open request will fail anyway.
-			Session.ActivateService<ConnectionService>();
-		}
 	}
 
 	private async Task RequestAuthenticationAsync(
@@ -409,11 +528,20 @@ internal class AuthenticationService : SshService
 			ConnectionService.Name,
 			username,
 			password);
+		SetCurrentRequest(authMessage);
 		await Session.SendMessageAsync(authMessage, cancellation).ConfigureAwait(false);
+	}
 
-		// Assume the included service request succeeds, without waiting for an auth success
-		// message. If not, a following channel open request will fail anyway.
-		Session.ActivateService<ConnectionService>();
+	private async Task RequestInteractiveAuthenticationAsync(
+		string username,
+		CancellationToken cancellation)
+	{
+		var authMessage = new AuthenticationRequestMessage(
+			ConnectionService.Name,
+			AuthenticationMethods.KeyboardInteractive,
+			username);
+		SetCurrentRequest(authMessage);
+		await Session.SendMessageAsync(authMessage, cancellation).ConfigureAwait(false);
 	}
 
 #pragma warning disable CA1801 // Remove unused parameter
@@ -421,18 +549,24 @@ internal class AuthenticationService : SshService
 		AuthenticationFailureMessage message, CancellationToken cancellation)
 #pragma warning restore CA1801 // Remove unused parameter
 	{
-		if (this.clientAuthenticationMethods!.Count > 0)
+		SetCurrentRequest(null);
+
+		while (this.clientAuthenticationMethods!.Count > 0)
 		{
 			var nextAuthMethod = this.clientAuthenticationMethods.Dequeue();
-			await nextAuthMethod(cancellation).ConfigureAwait(false);
-		}
-		else
-		{
-			// Revert the optimistic service registration.
-			Session.UnregisterService<ConnectionService>();
 
-			((SshClientSession)Session).OnAuthenticationComplete(false);
+			// Skip client auth methods that the server did not suggest.
+			if (message.MethodNames?.Contains(nextAuthMethod.Method) == true)
+			{
+				await nextAuthMethod.Handler(cancellation).ConfigureAwait(false);
+				return;
+			}
 		}
+
+		// Revert the optimistic service registration.
+		Session.UnregisterService<ConnectionService>();
+
+		((SshClientSession)Session).OnAuthenticationComplete(false);
 	}
 
 #pragma warning disable CA1801 // Remove unused parameter
@@ -440,6 +574,7 @@ internal class AuthenticationService : SshService
 		AuthenticationSuccessMessage message, CancellationToken cancellation)
 #pragma warning restore CA1801 // Remove unused parameter
 	{
+		SetCurrentRequest(null);
 		((SshClientSession)Session).OnAuthenticationComplete(true);
 		return Task.CompletedTask;
 	}

--- a/src/ts/ssh/events/sshAuthenticatingEventArgs.ts
+++ b/src/ts/ssh/events/sshAuthenticatingEventArgs.ts
@@ -223,7 +223,7 @@ export class SshAuthenticatingEventArgs {
 	public readonly clientUsername: string | null;
 
 	/**
-	 * Gets or sets a request more information for interactive authentication.
+	 * Gets or sets a request for more information for interactive authentication.
 	 *
 	 * The server may set this property when handling an interactive authenticating event to prompt
 	 * for information/credentials. The client may read this property when handling an interactive

--- a/src/ts/ssh/index.ts
+++ b/src/ts/ssh/index.ts
@@ -27,6 +27,18 @@ export { SshChannelClosedEventArgs } from './events/sshChannelClosedEventArgs';
 export { SshExtendedDataType, SshExtendedDataEventArgs } from './events/sshExtendedDataEventArgs';
 
 export { SshMessage } from './messages/sshMessage';
+export { AuthenticationMethod } from './messages/authenticationMethod';
+export {
+	AuthenticationMessage,
+	AuthenticationRequestMessage,
+	AuthenticationSuccessMessage,
+	AuthenticationFailureMessage,
+	AuthenticationInfoRequestMessage,
+	AuthenticationInfoResponseMessage,
+	PublicKeyRequestMessage,
+	PublicKeyOKMessage,
+	PasswordRequestMessage,
+} from './messages/authenticationMessages';
 export {
 	SessionRequestMessage,
 	DebugMessage,

--- a/src/ts/ssh/io/sshProtocol.ts
+++ b/src/ts/ssh/io/sshProtocol.ts
@@ -78,6 +78,8 @@ export class SshProtocol implements Disposable {
 
 	public algorithms: SshSessionAlgorithms | null = null;
 
+	public messageContext: string | null = null;
+
 	public outgoingMessagesHaveLatencyInfo = false;
 	public incomingMessagesHaveLatencyInfo = false;
 	public outgoingMessagesHaveReconnectInfo = false;
@@ -629,7 +631,7 @@ export class SshProtocol implements Disposable {
 		}
 
 		const messageType = payload[0];
-		let message = SshMessage.create(this.config, messageType, payload);
+		let message = SshMessage.create(this.config, messageType, this.messageContext, payload);
 
 		if (!message) {
 			const unimplementedMessage = new UnimplementedMessage();

--- a/src/ts/ssh/messages/authenticationMethod.ts
+++ b/src/ts/ssh/messages/authenticationMethod.ts
@@ -1,0 +1,14 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//
+
+/**
+ * Defines constants for standard authentication methods.
+ */
+export const enum AuthenticationMethod {
+	none = 'none',
+	publicKey = 'publickey',
+	password = 'password',
+	hostBased = 'hostbased',
+	keyboardInteractive = 'keyboard-interactive',
+}

--- a/src/ts/ssh/sshSession.ts
+++ b/src/ts/ssh/sshSession.ts
@@ -100,7 +100,7 @@ export class SshSession implements Disposable {
 	public readonly metrics = new SessionMetrics();
 
 	/* @internal */
-	protected protocol?: SshProtocol;
+	public protocol?: SshProtocol;
 
 	/* @internal */
 	public reconnecting: boolean = false;
@@ -170,6 +170,8 @@ export class SshSession implements Disposable {
 	public trace: Trace = (level, eventId, msg, err) => {};
 
 	public constructor(public readonly config: SshSessionConfiguration, isClientSession?: boolean) {
+		this.isClientSession = isClientSession ?? false;
+
 		if (!config) throw new TypeError('Session configuration is required.');
 
 		if (!config.keyExchangeAlgorithms.find((a) => !!a)) {
@@ -193,7 +195,7 @@ export class SshSession implements Disposable {
 			this.kexService = null;
 			this.activateService(ConnectionService);
 		} else {
-			this.kexService = new KeyExchangeService(this, isClientSession ?? false);
+			this.kexService = new KeyExchangeService(this);
 		}
 
 		config.onConfigurationChanged(() => {
@@ -203,6 +205,13 @@ export class SshSession implements Disposable {
 			}
 		});
 	}
+
+	/**
+	 * Allows other internal components to check whether a session is a client (or server),
+	 * without using `instanceof` which is slower and can cause circular dependencies.
+	 */
+	/* @internal */
+	public readonly isClientSession: boolean;
 
 	public get isConnected(): boolean {
 		return this.connected;

--- a/src/ts/ssh/sshSession.ts
+++ b/src/ts/ssh/sshSession.ts
@@ -170,7 +170,7 @@ export class SshSession implements Disposable {
 	public trace: Trace = (level, eventId, msg, err) => {};
 
 	public constructor(public readonly config: SshSessionConfiguration, isClientSession?: boolean) {
-		this.isClientSession = isClientSession ?? false;
+		this.isClientSession = isClientSession;
 
 		if (!config) throw new TypeError('Session configuration is required.');
 
@@ -211,7 +211,7 @@ export class SshSession implements Disposable {
 	 * without using `instanceof` which is slower and can cause circular dependencies.
 	 */
 	/* @internal */
-	public readonly isClientSession: boolean;
+	public readonly isClientSession?: boolean;
 
 	public get isConnected(): boolean {
 		return this.connected;

--- a/test/cs/Ssh.Test/InteropTests.cs
+++ b/test/cs/Ssh.Test/InteropTests.cs
@@ -139,7 +139,7 @@ public class InteropTests
 
 		var server = new SshServer(config, TestTS);
 		server.Credentials = new[] { serverKey };
-		server.ExceptionRasied += (sender, ex) => { Assert.Null(ex); };
+		server.ExceptionRaised += (sender, ex) => { Assert.Null(ex); };
 		var serverTask = server.AcceptSessionsAsync(TestPort, IPAddress.Loopback);
 
 		Process sshProcess = null;
@@ -565,7 +565,7 @@ public class InteropTests
 
 			var server = new SshServer(config, TestTS);
 			server.Credentials = new[] { serverKey };
-			server.ExceptionRasied += (sender, ex) => { Assert.Null(ex); };
+			server.ExceptionRaised += (sender, ex) => { Assert.Null(ex); };
 			var serverTask = server.AcceptSessionsAsync(JumpPort, IPAddress.Loopback);
 
 			server.SessionAuthenticating += (__, e) =>


### PR DESCRIPTION
 - Implement the `keyboard-interactive` SSH authentication protocol as defined in the RFC
   - Add `AuthenticationInfoRequest`, `AuthenticationInfoResponse`, and related properties to `SshAuthenticatingEventArgs`.
   - SSH server and client applications may handle the `Authenticating` event and use the new properties to participate in interactive authentication. The library itself does not implement any direct interactivity via console or otherwise.
 - Add the ability to configure enabled auth methods for a session. Disabling unused auth methods can make the auth exchange a little more efficient, and reduce attack surface.
 - Add the concept of "contextual" message number to message type mappings in config. This was necessary because authentication message numbers can map to different types depending on the current authentication request.
   - Specifically, `AuthenticationInfoRequest` and `PublicKeyOKMessage` are both `60`.
   - Technically other key-exchange methods may also overlap with DH message numbers, but the library only supports DH now (and ECDH which uses the same message types).
