### PR TITLE
Fix cs SSH API objects leak by Cancellation callback

### DIFF
--- a/src/cs/Ssh.Tcp/Ssh.Tcp.csproj
+++ b/src/cs/Ssh.Tcp/Ssh.Tcp.csproj
@@ -16,4 +16,8 @@
 	<ItemGroup>
 		<None Remove="Microsoft.DevTunnels.Ssh.Tcp.xml" />
 	</ItemGroup>
+
+	<ItemGroup>
+	  <Compile Include="..\Ssh\TaskExtensions.cs" Link="TaskExtensions.cs" />
+	</ItemGroup>
 </Project>

--- a/src/cs/Ssh/MultiChannelStream.cs
+++ b/src/cs/Ssh/MultiChannelStream.cs
@@ -148,10 +148,7 @@ public class MultiChannelStream : IDisposable
 		{
 			await ConnectAsync(cancellation).ConfigureAwait(false);
 
-			using var tokenRegistration = cancellation.CanBeCanceled ?
-				cancellation.Register(() => tcs.TrySetCanceled(cancellation)) : default;
-
-			var disconnectReason = await tcs.Task.ConfigureAwait(false);
+			var disconnectReason = await tcs.Task.WaitAsync(cancellation).ConfigureAwait(false);
 			if (disconnectReason != SshDisconnectReason.ByApplication && disconnectReason != SshDisconnectReason.None)
 			{
 				throw new SshConnectionException("SSH connection failed", disconnectReason);

--- a/src/cs/Ssh/SshChannel.cs
+++ b/src/cs/Ssh/SshChannel.cs
@@ -258,11 +258,6 @@ public class SshChannel : IDisposable
 		// Capture as a local variable because the member may change.
 		var requestCompletionSource = new TaskCompletionSource<bool>(
 			TaskCreationOptions.RunContinuationsAsynchronously);
-		if (cancellation.CanBeCanceled)
-		{
-			cancellation.Register(() => requestCompletionSource.TrySetCanceled());
-			cancellation.ThrowIfCancellationRequested();
-		}
 
 		await channelRequestSemaphore.WaitAsync(cancellation).ConfigureAwait(false);
 		try
@@ -275,7 +270,7 @@ public class SshChannel : IDisposable
 			channelRequestSemaphore.Release();
 		}
 
-		return await requestCompletionSource.Task.ConfigureAwait(false);
+		return await requestCompletionSource.Task.WaitAsync(cancellation).ConfigureAwait(false);
 	}
 
 	/// <summary>
@@ -504,7 +499,7 @@ public class SshChannel : IDisposable
 	{
 		if (this.requestCompletionSources.TryDequeue(out var completion))
 		{
-			completion.TrySetResult(result);
+				completion.TrySetResult(result);
 		}
 	}
 

--- a/src/cs/Ssh/SshClientSession.cs
+++ b/src/cs/Ssh/SshClientSession.cs
@@ -130,15 +130,11 @@ public class SshClientSession : SshSession
 	{
 		var completionSource = new TaskCompletionSource<bool>(
 			TaskCreationOptions.RunContinuationsAsynchronously);
-		if (cancellation.CanBeCanceled)
-		{
-			cancellation.Register(() => completionSource.TrySetCanceled());
-			cancellation.ThrowIfCancellationRequested();
-		}
 
 		await AuthenticateClientAsync(clientCredentials, completionSource, cancellation)
 			.ConfigureAwait(false);
-		return await completionSource.Task.ConfigureAwait(false);
+
+		return await completionSource.Task.WaitAsync(cancellation).ConfigureAwait(false);
 	}
 
 	/// <summary>
@@ -172,16 +168,6 @@ public class SshClientSession : SshSession
 		}
 
 		this.clientAuthCompletionSource = completion;
-
-		if (cancellation.CanBeCanceled)
-		{
-			if (completion != null)
-			{
-				cancellation.Register(() => completion.TrySetCanceled());
-			}
-
-			cancellation.ThrowIfCancellationRequested();
-		}
 
 		var authService = GetService<AuthenticationService>();
 		if (authService == null)

--- a/src/cs/Ssh/TaskExtensions.cs
+++ b/src/cs/Ssh/TaskExtensions.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -8,46 +9,67 @@ namespace Microsoft.DevTunnels.Ssh;
 internal static class TaskExtensions
 {
 	/// <summary>
-	/// Waits either for a task to complete for for a cancellation token to be cancelled.
+	/// Waits either for <paramref name="task"/> to complete or for <paramref name="cancellation"/> to be cancelled.
+	/// Throws any exception off <paramref name="task"/> if it completes first and is faulted.
+	/// If <paramref name="cancellation"/> is cancelled first, throws <see cref="OperationCanceledException"/>
+	/// from that cancellation, leaving <paramref name="task"/> run its course unobserved.
 	/// </summary>
+	/// <exception cref="ArgumentNullException">If <paramref name="task"/> is null.</exception>
+	/// <exception cref="OperationCanceledException">If <paramref name="cancellation"/> is cancelled first.</exception>
 	public static async Task WaitAsync(this Task task, CancellationToken cancellation)
 	{
-		if (cancellation.CanBeCanceled)
+		if (task == null)
 		{
-			var cancellationCompletionSource = new TaskCompletionSource<bool>(
-				TaskCreationOptions.RunContinuationsAsynchronously);
-			using (cancellation.Register(() => cancellationCompletionSource.SetCanceled()))
-			{
-				cancellation.ThrowIfCancellationRequested();
-				await Task.WhenAny(task, cancellationCompletionSource.Task).ConfigureAwait(false);
-			}
+			throw new ArgumentNullException(nameof(task));
 		}
-		else
+
+		if (!cancellation.CanBeCanceled)
 		{
 			await task.ConfigureAwait(false);
+			return;
 		}
+
+		cancellation.ThrowIfCancellationRequested();
+		var cancellationCompletionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+		using var cancellationRegistration = cancellation.Register(() => cancellationCompletionSource.TrySetCanceled(cancellation));
+		var firstTaskToComplete = await Task.WhenAny(task, cancellationCompletionSource.Task).ConfigureAwait(false);
+
+		// This may throw OperationCancelledException if the first task to complete is from cancellationCompletionSource.Task
+		// or throw any exceptions from executing task argument.
+		await firstTaskToComplete.ConfigureAwait(false);
 	}
 
 	/// <summary>
-	/// Waits either for a task to complete for for a cancellation token to be cancelled.
+	/// Waits either for <paramref name="task"/> to complete or for <paramref name="cancellation"/> to be cancelled.
+	/// If <paramref name="task"/> completes first, returns its result or throws it's exception if it faulted.
+	/// If <paramref name="cancellation"/> is cancelled first, throws <see cref="OperationCanceledException"/>
+	/// from that cancellation, leaving <paramref name="task"/> run its course unobserved.
 	/// </summary>
 	/// <typeparam name="T">The type of task to wait on.</typeparam>
+	/// <exception cref="ArgumentNullException">If <paramref name="task"/> is null.</exception>
+	/// <exception cref="OperationCanceledException">If <paramref name="cancellation"/> is cancelled first.</exception>
 	public static async Task<T> WaitAsync<T>(this Task<T> task, CancellationToken cancellation)
 	{
-		if (cancellation.CanBeCanceled)
+		if (task == null)
 		{
-			var cancellationCompletionSource = new TaskCompletionSource<bool>(
-				TaskCreationOptions.RunContinuationsAsynchronously);
-			using (cancellation.Register(() => cancellationCompletionSource.SetCanceled()))
-			{
-				cancellation.ThrowIfCancellationRequested();
-				await Task.WhenAny(task, cancellationCompletionSource.Task).ConfigureAwait(false);
-				return task.Result;
-			}
+			throw new ArgumentNullException(nameof(task));
 		}
-		else
+
+		if (!cancellation.CanBeCanceled)
 		{
 			return await task.ConfigureAwait(false);
 		}
+
+		cancellation.ThrowIfCancellationRequested();
+		var cancellationCompletionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+		using var cancellationRegistration = cancellation.Register(() => cancellationCompletionSource.TrySetCanceled(cancellation));
+		var firstTaskToComplete = await Task.WhenAny(task, cancellationCompletionSource.Task).ConfigureAwait(false);
+		if (firstTaskToComplete != task)
+		{
+			// This will throw OperationCanceledException.
+			await firstTaskToComplete.ConfigureAwait(false);
+		}
+
+		return await task.ConfigureAwait(false);
 	}
 }

--- a/test/cs/Ssh.Test/InteropTests.cs
+++ b/test/cs/Ssh.Test/InteropTests.cs
@@ -774,7 +774,7 @@ public class InteropTests
 			var acceptTask = clientListener.AcceptTcpClientAsync();
 
 			using var serverConnection = new TcpClient();
-			await TaskExtensions.WaitUntil(async () =>
+			await TestTaskExtensions.WaitUntil(async () =>
 			{
 				try
 				{
@@ -814,14 +814,14 @@ public class InteropTests
 		SshClientSession session = client.Sessions.Single();
 
 		// Reconnect is not enabled until a few messages are exchanged.
-		await TaskExtensions.WaitUntil(() =>
+		await TestTaskExtensions.WaitUntil(() =>
 			session.ProtocolExtensions?.ContainsKey(
 				SshProtocolExtensionNames.SessionReconnect) == true).WithTimeout(Timeout);
 
 		client.Disconnect();
 
 		// Wait for async processing of the disconnection.
-		await TaskExtensions.WaitUntil(() => !session.IsConnected).WithTimeout(Timeout);
+		await TestTaskExtensions.WaitUntil(() => !session.IsConnected).WithTimeout(Timeout);
 
 		Assert.False(session.IsConnected);
 

--- a/test/cs/Ssh.Test/MetricsTests.cs
+++ b/test/cs/Ssh.Test/MetricsTests.cs
@@ -143,7 +143,7 @@ public class MetricsTests : IDisposable
 		await this.clientSession.CloseAsync(SshDisconnectReason.ByApplication);
 		await this.serverSession.CloseAsync(SshDisconnectReason.ByApplication);
 
-		await TaskExtensions.WaitUntil(() =>
+		await TestTaskExtensions.WaitUntil(() =>
 			this.clientSession.Metrics.LatencyCurrentMs == 0 &&
 			this.serverSession.Metrics.LatencyCurrentMs == 0).WithTimeout(Timeout);
 	}

--- a/test/cs/Ssh.Test/PortForwardingTests.cs
+++ b/test/cs/Ssh.Test/PortForwardingTests.cs
@@ -321,7 +321,7 @@ public class PortForwardingTests : IDisposable
 			Assert.Equal(0, count);
 
 			// The channel will be closed asynchronously.
-			await TaskExtensions.WaitUntil(() => forwardingChannel.IsClosed).WithTimeout(Timeout);
+			await TestTaskExtensions.WaitUntil(() => forwardingChannel.IsClosed).WithTimeout(Timeout);
 		}
 		finally
 		{
@@ -367,7 +367,7 @@ public class PortForwardingTests : IDisposable
 			var localClient = await acceptTask.WithTimeout(Timeout);
 			var localStream = localClient.GetStream();
 
-			await TaskExtensions.WaitUntil(() =>
+			await TestTaskExtensions.WaitUntil(() =>
 			{
 				return clientForwardingChannel != null && serverForwardingChannel != null;
 			}).WithTimeout(Timeout);
@@ -398,7 +398,7 @@ public class PortForwardingTests : IDisposable
 		forwarder.Dispose();
 
 		// Wait until a connection failure indicates forwarding was successfully cancelled.
-		await TaskExtensions.WaitUntil(async () =>
+		await TestTaskExtensions.WaitUntil(async () =>
 		{
 			var remoteClient = new TcpClient();
 			try
@@ -461,7 +461,7 @@ public class PortForwardingTests : IDisposable
 			var localClient = await acceptTask.WithTimeout(Timeout);
 			var localStream = localClient.GetStream();
 
-			await TaskExtensions.WaitUntil(() =>
+			await TestTaskExtensions.WaitUntil(() =>
 			{
 				return clientForwardingChannel != null && serverForwardingChannel != null;
 			}).WithTimeout(Timeout);
@@ -472,7 +472,7 @@ public class PortForwardingTests : IDisposable
 			await AssertSocketStreamClosedAsync(remoteEnd ? localStream : remoteStream);
 
 			// The channel will be closed asynchronously.
-			await TaskExtensions.WaitUntil(() => clientForwardingChannel.IsClosed)
+			await TestTaskExtensions.WaitUntil(() => clientForwardingChannel.IsClosed)
 				.WithTimeout(Timeout);
 		}
 		finally
@@ -584,7 +584,7 @@ public class PortForwardingTests : IDisposable
 		await localClient.ConnectAsync(IPAddress.Loopback, TestPort1);
 		var localStream = localClient.GetStream();
 
-		await TaskExtensions.WaitUntil(() => forwardingChannel != null);
+		await TestTaskExtensions.WaitUntil(() => forwardingChannel != null);
 
 		var ioex = await Assert.ThrowsAsync<IOException>(async () =>
 		{
@@ -594,7 +594,7 @@ public class PortForwardingTests : IDisposable
 		Assert.IsType<SocketException>(ioex.InnerException);
 
 		// The channel will be closed asynchronously.
-		await TaskExtensions.WaitUntil(() => forwardingChannel.IsClosed).WithTimeout(Timeout);
+		await TestTaskExtensions.WaitUntil(() => forwardingChannel.IsClosed).WithTimeout(Timeout);
 	}
 
 	[Theory]
@@ -737,7 +737,7 @@ public class PortForwardingTests : IDisposable
 			Assert.Equal(0, count);
 
 			// The channel will be closed asynchronously.
-			await TaskExtensions.WaitUntil(() => forwardingChannel.IsClosed).WithTimeout(Timeout);
+			await TestTaskExtensions.WaitUntil(() => forwardingChannel.IsClosed).WithTimeout(Timeout);
 		}
 		finally
 		{
@@ -783,7 +783,7 @@ public class PortForwardingTests : IDisposable
 			var remoteClient = await acceptTask.WithTimeout(Timeout);
 			var remoteStream = remoteClient.GetStream();
 
-			await TaskExtensions.WaitUntil(() =>
+			await TestTaskExtensions.WaitUntil(() =>
 			{
 				return clientForwardingChannel != null && serverForwardingChannel != null;
 			}).WithTimeout(Timeout);
@@ -811,7 +811,7 @@ public class PortForwardingTests : IDisposable
 		forwarder.Dispose();
 
 		// Wait until a connection failure indicates forwarding was successfully cancelled.
-		await TaskExtensions.WaitUntil(async () =>
+		await TestTaskExtensions.WaitUntil(async () =>
 		{
 			var localClient = new TcpClient();
 			try
@@ -877,7 +877,7 @@ public class PortForwardingTests : IDisposable
 			await AssertSocketStreamClosedAsync(remoteEnd ? localStream : remoteStream);
 
 			// The channel will be closed asynchronously.
-			await TaskExtensions.WaitUntil(() => forwardingChannel.IsClosed).WithTimeout(Timeout);
+			await TestTaskExtensions.WaitUntil(() => forwardingChannel.IsClosed).WithTimeout(Timeout);
 		}
 		finally
 		{
@@ -1311,9 +1311,9 @@ public class PortForwardingTests : IDisposable
 			localServer.Stop();
 		}
 
-		await TaskExtensions.WaitUntil(() => serverRemoteChannelRemovedEvent != null)
+		await TestTaskExtensions.WaitUntil(() => serverRemoteChannelRemovedEvent != null)
 			.WithTimeout(Timeout);
-		await TaskExtensions.WaitUntil(() => clientLocalChannelRemovedEvent != null)
+		await TestTaskExtensions.WaitUntil(() => clientLocalChannelRemovedEvent != null)
 			.WithTimeout(Timeout);
 
 		var clientLocalForwardedPort2 = clientPfs.LocalForwardedPorts.Single();
@@ -1333,9 +1333,9 @@ public class PortForwardingTests : IDisposable
 
 		forwarder.Dispose();
 
-		await TaskExtensions.WaitUntil(() => clientLocalPortRemovedEvent != null)
+		await TestTaskExtensions.WaitUntil(() => clientLocalPortRemovedEvent != null)
 			.WithTimeout(Timeout);
-		await TaskExtensions.WaitUntil(() => serverRemotePortRemovedEvent != null)
+		await TestTaskExtensions.WaitUntil(() => serverRemotePortRemovedEvent != null)
 			.WithTimeout(Timeout);
 
 		Assert.Empty(clientPfs.LocalForwardedPorts);
@@ -1470,7 +1470,7 @@ public class PortForwardingTests : IDisposable
 		forwarder1.Dispose();
 
 		// Wait until a connection failure indicates forwarding was successfully cancelled.
-		await TaskExtensions.WaitUntil(async () =>
+		await TestTaskExtensions.WaitUntil(async () =>
 		{
 			var remoteClient = new TcpClient();
 			try

--- a/test/cs/Ssh.Test/ReconnectTests.cs
+++ b/test/cs/Ssh.Test/ReconnectTests.cs
@@ -116,7 +116,7 @@ public class ReconnectTests : IDisposable
 		if (waitUntilDisconnected)
 		{
 			// Avoid test timing problems by waiting until the sessions are fully disconnected.
-			await TaskExtensions.WaitUntil(() =>
+			await TestTaskExtensions.WaitUntil(() =>
 				!this.clientSession.IsConnected &&
 				!this.serverSession.IsConnected).WithTimeout(Timeout);
 		}
@@ -167,13 +167,13 @@ public class ReconnectTests : IDisposable
 		Assert.True(this.clientSession.IsConnected);
 
 		// Reconnect is not enabled until a few messages are exchanged.
-		await TaskExtensions.WaitUntil(() =>
+		await TestTaskExtensions.WaitUntil(() =>
 			this.serverSession.ProtocolExtensions?.ContainsKey(
 				SshProtocolExtensionNames.SessionReconnect) == true &&
 			this.clientSession.ProtocolExtensions?.ContainsKey(
 				SshProtocolExtensionNames.SessionReconnect) == true);
 
-		await TaskExtensions.WaitUntil(() =>
+		await TestTaskExtensions.WaitUntil(() =>
 		{
 			lock (this.reconnectableSessions)
 			{
@@ -623,7 +623,7 @@ public class ReconnectTests : IDisposable
 		await this.serverDisconnectedCompletion.Task.WithTimeout(Timeout);
 
 		// Avoid test timing problems by waiting until the sessions are fully disconnected.
-		await TaskExtensions.WaitUntil(() =>
+		await TestTaskExtensions.WaitUntil(() =>
 			!this.clientSession.IsConnected &&
 			!this.serverSession.IsConnected).WithTimeout(Timeout);
 
@@ -664,7 +664,7 @@ public class ReconnectTests : IDisposable
 		await this.serverDisconnectedCompletion.Task.WithTimeout(Timeout);
 
 		// Avoid test timing problems by waiting until the sessions are fully disconnected.
-		await TaskExtensions.WaitUntil(() =>
+		await TestTaskExtensions.WaitUntil(() =>
 			!this.clientSession.IsConnected &&
 			!this.serverSession.IsConnected).WithTimeout(Timeout);
 
@@ -764,7 +764,7 @@ public class ReconnectTests : IDisposable
 		this.sessionPair.ServerStream.Dispose();
 		this.sessionPair.ClientStream.MockDisconnect(new Exception("Mock disconnect."), 36);
 
-		await TaskExtensions.WaitUntil(() =>
+		await TestTaskExtensions.WaitUntil(() =>
 			!this.clientSession.IsConnected &&
 			!this.serverSession.IsConnected).WithTimeout(Timeout);
 
@@ -774,7 +774,7 @@ public class ReconnectTests : IDisposable
 		await ReconnectAsync(mockLatency: 10);
 
 		// Verify some messages were received after reconnection.
-		await TaskExtensions.WaitUntil(() =>
+		await TestTaskExtensions.WaitUntil(() =>
 			 serverChannel.Metrics.BytesReceived > serverBytesReceivedBeforeReconnect &&
 				clientChannel.Metrics.BytesReceived > clientBytesReceivedBeforeReconnect)
 			.WithTimeout(Timeout);

--- a/test/cs/Ssh.Test/SessionTests.cs
+++ b/test/cs/Ssh.Test/SessionTests.cs
@@ -521,7 +521,7 @@ public class SessionTests : IDisposable
 		Assert.True(ex is SshConnectionException || ex is ObjectDisposedException);
 
 		// The sessions should both be closed (not merely disconnected).
-		await TaskExtensions.WaitUntil(() =>
+		await TestTaskExtensions.WaitUntil(() =>
 			!this.clientSession.IsConnected && this.clientSession.IsClosed &&
 			!this.serverSession.IsConnected && this.serverSession.IsClosed)
 			.WithTimeout(Timeout);

--- a/test/cs/Ssh.Test/Ssh.Test.csproj
+++ b/test/cs/Ssh.Test/Ssh.Test.csproj
@@ -22,6 +22,10 @@
 	</ItemGroup>
 
 	<ItemGroup>
+	  <Compile Include="..\..\..\src\cs\Ssh\TaskExtensions.cs" Link="TaskExtensions.cs" />
+	</ItemGroup>
+
+	<ItemGroup>
 		<None Update="xunit.runner.json">
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</None>

--- a/test/cs/Ssh.Test/TaskExtensionsTests.cs
+++ b/test/cs/Ssh.Test/TaskExtensionsTests.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.DevTunnels.Ssh.Test;
+
+#if !NET6_0_OR_GREATER
+
+public class TaskExtensionsTests
+{
+	[Fact]
+	public async Task WaitAsync_ThrowsForNullTask()
+	{
+		await Assert.ThrowsAsync<ArgumentNullException>(() => ((Task)null).WaitAsync(default));
+		await Assert.ThrowsAsync<ArgumentNullException>(() => ((Task<bool>)null).WaitAsync(default));
+	}
+
+	[Fact]
+	public async Task WaitAsync_ThrowsForCancellation()
+	{
+		using var cts = new CancellationTokenSource();
+		cts.Cancel();
+
+		await Assert.ThrowsAsync<OperationCanceledException>(() => Task.CompletedTask.WaitAsync(cts.Token));
+		await Assert.ThrowsAsync<OperationCanceledException>(() => Task.FromResult(true).WaitAsync(cts.Token));
+	}
+
+	[Fact]
+	public async Task WaitAsync_CannotBeCancelled()
+	{
+		await Task.CompletedTask.WaitAsync(default);
+		Assert.True(await Task.FromResult(true).WaitAsync(default));
+	}
+
+	[Fact]
+	public async Task WaitAsync_Cancelled()
+	{
+		using var cts = new CancellationTokenSource();
+		var tcs = new TaskCompletionSource<bool>();
+
+		var task1 = (tcs.Task as Task).WaitAsync(cts.Token);
+		var task2 = tcs.Task.WaitAsync(cts.Token);
+
+		Assert.False(task1.IsCompleted);
+		Assert.False(task2.IsCompleted);
+
+		cts.Cancel();
+
+		Assert.Equal(cts.Token, (await Assert.ThrowsAnyAsync<OperationCanceledException>(() => task1)).CancellationToken);
+		Assert.Equal(cts.Token, (await Assert.ThrowsAnyAsync<OperationCanceledException>(() => task2)).CancellationToken);
+	}
+
+	[Fact]
+	public async Task WaitAsync_ReturnsResult()
+	{
+
+		using var cts = new CancellationTokenSource();
+		var tcs = new TaskCompletionSource<bool>();
+
+		var task1 = (tcs.Task as Task).WaitAsync(cts.Token);
+		var task2 = tcs.Task.WaitAsync(cts.Token);
+
+		Assert.False(task1.IsCompleted);
+		Assert.False(task2.IsCompleted);
+
+		tcs.SetResult(true);
+
+		await task1;
+		Assert.True(await task2);
+	}
+
+	[Fact]
+	public async Task WaitAsync_ThrowsException()
+	{
+		using var cts = new CancellationTokenSource();
+		var tcs = new TaskCompletionSource<bool>();
+
+		var task1 = (tcs.Task as Task).WaitAsync(cts.Token);
+		var task2 = tcs.Task.WaitAsync(cts.Token);
+
+		Assert.False(task1.IsCompleted);
+		Assert.False(task2.IsCompleted);
+
+		var exception = new InvalidOperationException();
+		tcs.SetException(exception);
+
+		Assert.Equal(exception, await Assert.ThrowsAsync<InvalidOperationException>(() => task1));
+		Assert.Equal(exception, await Assert.ThrowsAsync<InvalidOperationException>(() => task2));
+	}
+}
+
+#endif

--- a/test/cs/Ssh.Test/TestTaskExtensions.cs
+++ b/test/cs/Ssh.Test/TestTaskExtensions.cs
@@ -5,7 +5,8 @@ using System.Threading.Tasks;
 
 namespace Microsoft.DevTunnels.Ssh.Test;
 
-static class TaskExtensions
+static class TestTaskExtensions
+
 {
 	public static async Task WithTimeout(this Task t, TimeSpan timeout)
 	{


### PR DESCRIPTION
Fix for #79 

SSH APIs may be called with a long living `CancellationToken`. The API must not register cancellation callback without unregistering it.

Replace cancellation callback registration with `Task.WaitAsync()` in some places.

Fix `TaskExtensions` and add unit tests for it. The issue was that `Task.WaitAny` never throws and just returns the first to complete task. If that task was due to cancellation, it would not observe this, and, instead, synchronously wait for the main `task` to finish.

I verified that memory leak of `SshSession` objects pinned by `CancellationToken` arg has been fixed in local test Dev Tunnels service using the SSH library with the fix.

The bug and the fix is specific to cs.