### PR TITLE
Fix public-key query message handling

### DIFF
--- a/src/ts/ssh/index.ts
+++ b/src/ts/ssh/index.ts
@@ -46,6 +46,9 @@ export {
 	SessionRequestFailureMessage,
 	SshDisconnectReason,
 	SshReconnectFailureReason,
+	ServiceRequestMessage,
+	ServiceAcceptMessage,
+	SessionChannelRequestMessage,
 } from './messages/transportMessages';
 export {
 	SshChannelOpenFailureReason,

--- a/src/ts/ssh/services/authenticationService.ts
+++ b/src/ts/ssh/services/authenticationService.ts
@@ -90,7 +90,6 @@ export class AuthenticationService extends SshService {
 			SshTraceEventIds.sessionAuthenticating,
 			`Authentication request: ${message.methodName}`,
 		);
-		this.setCurrentRequest(message);
 
 		let methodName: AuthenticationMethod | null = message.methodName!;
 		if (!this.session.config.authenticationMethods.includes(methodName)) {
@@ -101,18 +100,18 @@ export class AuthenticationService extends SshService {
 			methodName === AuthenticationMethod.publicKey ||
 			methodName === AuthenticationMethod.hostBased
 		) {
-			return this.handlePublicKeyRequestMessage(
-				message.convertTo(new PublicKeyRequestMessage()),
-				cancellation,
-			);
+			const publicKeymessage = message.convertTo(new PublicKeyRequestMessage());
+			this.setCurrentRequest(publicKeymessage);
+			return this.handlePublicKeyRequestMessage(publicKeymessage, cancellation);
 		} else if (methodName === AuthenticationMethod.password) {
-			return this.handlePasswordRequestMessage(
-				message.convertTo(new PasswordRequestMessage()),
-				cancellation,
-			);
+			const passwordMessage = message.convertTo(new PasswordRequestMessage());
+			this.setCurrentRequest(passwordMessage);
+			return this.handlePasswordRequestMessage(passwordMessage, cancellation);
 		} else if (methodName === AuthenticationMethod.keyboardInteractive) {
+			this.setCurrentRequest(message);
 			return this.beginInteractiveAuthentication(message, cancellation);
 		} else if (methodName === AuthenticationMethod.none) {
+			this.setCurrentRequest(message);
 			return this.handleAuthenticating(
 				new SshAuthenticatingEventArgs(SshAuthenticationType.clientNone, {
 					username: message.username,

--- a/test/cs/Ssh.Test/InteropTests.cs
+++ b/test/cs/Ssh.Test/InteropTests.cs
@@ -383,6 +383,7 @@ public class InteropTests
 				$" -p {TestPort}" +
 				$" -f \"{configFile}\"" +
 				$" -o \"AuthorizedKeysFile={authorizedKeysFile}\"" +
+				$" -o \"StrictModes=no\"" + // Do not check permissions on key file/dir
 				$" -o \"PidFile={pidFile}\"" +
 				$" -o \"HostKey={hostKeyFile}\"";
 			TestTS.TraceInformation($"{exePath} {args}");
@@ -534,6 +535,7 @@ public class InteropTests
 				$" -p {TestPort}" +
 				$" -f \"{configFile}\"" +
 				$" -o \"AuthorizedKeysFile={authorizedKeysFile}\"" +
+				$" -o \"StrictModes=no\"" + // Do not check permissions on key file/dir
 				$" -o \"PidFile={pidFile}\"" +
 				$" -o \"HostKey={hostKeyFile}\"";
 			TestTS.TraceInformation($"{sshdExePath} {args}");

--- a/test/ts/ssh-test/interopTests.ts
+++ b/test/ts/ssh-test/interopTests.ts
@@ -351,6 +351,8 @@ export class InteropTests {
 				'-o',
 				'AuthorizedKeysFile=' + authorizedKeysFile,
 				'-o',
+				'StrictModes=no', // Do not check permissions on key file/dir
+				'-o',
 				'PidFile=' + pidFile,
 				'-o',
 				'HostKey=' + hostKeyFile,


### PR DESCRIPTION
This fixes an exception that was thrown when handling PublicKeyQuery messages. The SSH library does not normally _send_ PublicKeyQuery messages, but it may handle them when sent by other clients such as the `ssh` tool. The exception was a regression introduced by the [SSH interactive auth implementation](https://github.com/microsoft/dev-tunnels-ssh/pull/76).

```
System.InvalidCastException: Unable to cast object of type 'Microsoft.DevTunnels.Ssh.Messages.AuthenticationRequestMessage' to type 'Microsoft.DevTunnels.Ssh.Messages.PublicKeyRequestMessage'.
   at Microsoft.DevTunnels.Ssh.Services.AuthenticationService.HandleAuthenticatingAsync(SshAuthenticatingEventArgs args, CancellationToken cancellation)
   at Microsoft.DevTunnels.Ssh.Services.AuthenticationService.HandleMessageAsync(PublicKeyRequestMessage message, CancellationToken cancellation)
   at Microsoft.DevTunnels.Ssh.Services.AuthenticationService.HandleMessageAsync(AuthenticationRequestMessage message, CancellationToken cancellation)
   at Microsoft.DevTunnels.Ssh.SshSession.HandleMessageAsync(AuthenticationMessage message, CancellationToken cancellation)
```