### PR TITLE
Fix port-forwarding connection error-handling

### DIFF
--- a/src/cs/Ssh.Tcp/Services/PortForwardingService.cs
+++ b/src/cs/Ssh.Tcp/Services/PortForwardingService.cs
@@ -899,6 +899,11 @@ public class PortForwardingService : SshService
 					remotePort: (int)portForwardMessage.Port,
 					Session.Trace,
 					cancellation).ConfigureAwait(false);
+
+				if (request.FailureReason != SshChannelOpenFailureReason.None)
+				{
+					await request.Channel.CloseAsync(cancellation).ConfigureAwait(false);
+				}
 			}
 		}
 	}

--- a/src/cs/Ssh.Tcp/Services/RemotePortForwarder.cs
+++ b/src/cs/Ssh.Tcp/Services/RemotePortForwarder.cs
@@ -131,8 +131,8 @@ public class RemotePortForwarder : RemotePortConnector
 		}
 		catch (SocketException sockex)
 		{
-			var traceErrorMessage = $"{nameof(PortForwardingService)} forwarded channel " +
-				$"#{channel.ChannelId} connection to {localHost}:{localPort} failed: {sockex.Message}";
+			var traceErrorMessage = $"{nameof(PortForwardingService)} connection " +
+				$" to {localHost}:{localPort} failed: {sockex.Message}";
 			trace.TraceEvent(
 				TraceEventType.Warning,
 				SshTraceEventIds.PortForwardConnectionFailed,
@@ -157,8 +157,7 @@ public class RemotePortForwarder : RemotePortConnector
 		}
 		catch (ObjectDisposedException ex)
 		{
-			// The TCP connection was closed immediately after it was opened. Close the channel.
-			await channel.CloseAsync(cancellation).ConfigureAwait(false);
+			// The TCP connection was closed immediately after it was opened.
 			request.FailureReason = SshChannelOpenFailureReason.ConnectFailed;
 			request.FailureDescription = ex.Message;
 			return;
@@ -218,7 +217,7 @@ public class RemotePortForwarder : RemotePortConnector
 			connectTask, Task.Delay(connectionAttemptDelay, cancellation)).ConfigureAwait(false);
 		if (completedOrFaultedTask == connectTask)
 		{
-			if (completedOrFaultedTask.IsCompleted)
+			if (!completedOrFaultedTask.IsFaulted)
 			{
 				// The first connection attempt succeeded before the attempt delay elapsed.
 				// There's no need to try the second TCP client.
@@ -251,7 +250,7 @@ public class RemotePortForwarder : RemotePortConnector
 				.ConfigureAwait(false);
 			if (completedOrFaultedTask == connectTask)
 			{
-				if (completedOrFaultedTask.IsCompleted)
+				if (!completedOrFaultedTask.IsFaulted)
 				{
 					// The first connection attempt succeeded before the second one.
 					tcpClient2.Dispose();
@@ -268,7 +267,7 @@ public class RemotePortForwarder : RemotePortConnector
 			}
 			else
 			{
-				if (completedOrFaultedTask.IsCompleted)
+				if (!completedOrFaultedTask.IsFaulted)
 				{
 					// The second connection attempt succeeded before the first one.
 					tcpClient.Dispose();

--- a/src/ts/ssh-tcp/services/portForwardingService.ts
+++ b/src/ts/ssh-tcp/services/portForwardingService.ts
@@ -864,6 +864,10 @@ export class PortForwardingService extends SshService {
 					this.trace,
 					cancellation,
 				);
+
+				if (request.failureReason !== SshChannelOpenFailureReason.none) {
+					await request.channel.close(cancellation);
+				}
 			}
 		}
 	}

--- a/src/ts/ssh-tcp/services/remotePortForwarder.ts
+++ b/src/ts/ssh-tcp/services/remotePortForwarder.ts
@@ -123,10 +123,10 @@ export class RemotePortForwarder extends RemotePortConnector {
 			}
 
 			trace(
-				TraceLevel.Error,
+				TraceLevel.Warning,
 				SshTraceEventIds.portForwardConnectionFailed,
-				`${channel.session} PortForwardingService forwarded channel #${channel.channelId} ` +
-					`connection to ${localHost}:${localPort} failed: ${e.message}`,
+				`PortForwardingService connection ` +
+					`to ${localHost}:${localPort} failed: ${e.message}`,
 				e,
 			);
 			request.failureReason = SshChannelOpenFailureReason.connectFailed;


### PR DESCRIPTION
Fix error-handling when opening connections to a local port on the server-side of port-forwarding. It was broken due to incorrect interpretation of `Task.IsCompleted`: that can also be true when the task is faulted. (There is an `IsCompletedSuccessfully` property, but it isn't available in .NET Framework, which this code still targets.)

Also (in both C# and TS) ensure the channel is closed when the connection fails, and simplify the error message.