### PR TITLE
Fix TaskChain scheduling being not sequential

### DIFF
--- a/src/cs/Ssh.Tcp/Messages/PortForwardChannelOpenMessage.cs
+++ b/src/cs/Ssh.Tcp/Messages/PortForwardChannelOpenMessage.cs
@@ -31,4 +31,8 @@ public class PortForwardChannelOpenMessage : ChannelOpenMessage
 		writer.Write(OriginatorIPAddress ?? string.Empty, Encoding.ASCII);
 		writer.Write(OriginatorPort);
 	}
+
+	public override string ToString() =>
+		$"{GetType().Name} ChannelType: {ChannelType}, SenderChannel: {SenderChannel}, " +
+		$"Host: {Host}, Port: {Port}, OriginatorIPAddress: {OriginatorIPAddress}, OriginatorPort: {OriginatorPort}";
 }

--- a/test/cs/Ssh.Test/TaskChainTests.cs
+++ b/test/cs/Ssh.Test/TaskChainTests.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.DevTunnels.Ssh.Test;
+
+public class TaskChainTests
+{
+	public TaskChainTests()
+	{
+		Trace = new TraceSource("test");
+		TaskChain = new TaskChain(Trace);
+	}
+
+	private TraceSource Trace { get; }
+
+	private TaskChain TaskChain { get; }
+
+	[Fact]
+	public async Task RunInSequence_WhenTaskIsDisposed_ShouldCallOnError()
+	{
+		// Arrange
+		Exception exception = null;
+		TaskChain.Dispose();
+
+		// Act
+		await TaskChain.RunInSequence(
+			() => Task.CompletedTask, (e) => exception = e, CancellationToken.None);
+
+		// Assert
+		Assert.IsType<ObjectDisposedException>(exception);
+	}
+
+	[Fact]
+	public async Task RunInSequence_ExecutesInSequence()
+	{
+		const int TaskCount = 20;
+
+		// Arrange
+		var syncRoot = new object();
+		var random = new Random();
+		var taskNumbers = new List<int>();
+		Exception exception = null;
+
+		// Act
+		for (int i = 0; i < TaskCount; i++)
+		{
+			await TaskChain.RunInSequence(CreateTask(i), (e) => exception = e, CancellationToken.None);
+		}
+
+		await TaskChain.WaitForAllCurrentTasks(CancellationToken.None);
+
+		// Assert
+		Assert.Null(exception);
+		Assert.Equal(Enumerable.Range(0, TaskCount), taskNumbers);
+
+		Func<Task> CreateTask(int iteration) =>
+			async () =>
+			{
+				int delayMs;
+				lock (syncRoot)
+				{
+					delayMs = random.Next(20);
+				}
+
+				await Task.Delay(delayMs);
+				lock (syncRoot)
+				{
+					taskNumbers.Add(iteration);
+				}
+			};
+	}
+}


### PR DESCRIPTION
Fix for [#1618](https://github.com/devdiv-microsoft/basis-planning/issues/1618)

The problem was that `TaskChain` scheduled continuations to keep the task order for task-producing functions, not for the task that they produce. The continuation task was `Task<Task>` The fix was to use `Unwrap` so the continuation task waits for the async code and its result is just `Task`.

Add unit tests for more overlapping session requests. 
Add unit tests for `TaskChain` class.