### PR TITLE
Add remote port parameter to TCP listener factory

### DIFF
--- a/src/cs/Ssh.Tcp/DefaultTcpListenerFactory.cs
+++ b/src/cs/Ssh.Tcp/DefaultTcpListenerFactory.cs
@@ -16,9 +16,10 @@ internal class DefaultTcpListenerFactory : ITcpListenerFactory
 {
 	/// <inheritdoc />
 	public Task<TcpListener> CreateTcpListenerAsync(
+		int? remotePort,
 		IPAddress localIPAddress,
 		int localPort,
-		bool canChangePort,
+		bool canChangeLocalPort,
 		TraceSource trace,
 		CancellationToken cancellation)
 	{

--- a/src/cs/Ssh.Tcp/ITcpListenerFactory.cs
+++ b/src/cs/Ssh.Tcp/ITcpListenerFactory.cs
@@ -18,11 +18,13 @@ public interface ITcpListenerFactory
 	/// Creates and starts a TCP listener for the specified local network address and port
 	/// number.
 	/// </summary>
+	/// <param name="remotePort">The remote port that this local port will connect to (if known).
+	/// </param>
 	/// <param name="localIPAddress">Local IP address to listen on.</param>
 	/// <param name="localPort">Requested local port to listen on, or 0 to use a random
 	/// available port number.</param>
-	/// <param name="canChangePort">True if the factory is allowed to select a different
-	/// port number than the one that was requested; if false then the factory must either
+	/// <param name="canChangeLocalPort">True if the factory is allowed to select a different
+	/// local port number than the one that was requested; if false then the factory must either
 	/// use the requested port or throw an exception.</param>
 	/// <param name="trace">Trace source.</param>
 	/// <param name="cancellation">Cancellation token.</param>
@@ -43,9 +45,10 @@ public interface ITcpListenerFactory
 	/// <see cref="TcpListener.LocalEndpoint"/> property.
 	/// </remarks>
 	Task<TcpListener> CreateTcpListenerAsync(
+		int? remotePort,
 		IPAddress localIPAddress,
 		int localPort,
-		bool canChangePort,
+		bool canChangeLocalPort,
 		TraceSource trace,
 		CancellationToken cancellation);
 }

--- a/src/cs/Ssh.Tcp/Services/LocalPortForwarder.cs
+++ b/src/cs/Ssh.Tcp/Services/LocalPortForwarder.cs
@@ -76,8 +76,12 @@ public class LocalPortForwarder : SshService
 		{
 			var trace = this.pfs.Session.Trace;
 			this.listener = await this.pfs.TcpListenerFactory.CreateTcpListenerAsync(
-				listenAddress, LocalPort, canChangePort: true, trace, cancellation)
-				.ConfigureAwait(false);
+				RemotePort,
+				listenAddress,
+				LocalPort,
+				canChangeLocalPort: true,
+				trace,
+				cancellation).ConfigureAwait(false);
 
 			LocalPort = ((IPEndPoint)this.listener.LocalEndpoint).Port;
 
@@ -94,8 +98,12 @@ public class LocalPortForwarder : SshService
 				try
 				{
 					this.listener2 = await this.pfs.TcpListenerFactory.CreateTcpListenerAsync(
-						listenAddress, LocalPort, canChangePort: false, trace, cancellation)
-						.ConfigureAwait(false);
+						RemotePort,
+						listenAddress,
+						LocalPort,
+						canChangeLocalPort: false,
+						trace,
+						cancellation).ConfigureAwait(false);
 				}
 				catch (SocketException sockex)
 				when (sockex.SocketErrorCode == SocketError.AddressNotAvailable)

--- a/src/cs/Ssh.Tcp/SshServer.cs
+++ b/src/cs/Ssh.Tcp/SshServer.cs
@@ -79,9 +79,10 @@ public class SshServer : IDisposable
 		try
 		{
 			listener = await TcpListenerFactory.CreateTcpListenerAsync(
+				remotePort: null,
 				localAddress,
 				localPort,
-				canChangePort: false,
+				canChangeLocalPort: false,
 				this.trace,
 				CancellationToken.None)
 				.ConfigureAwait(false);

--- a/src/ts/ssh-tcp/services/localPortForwarder.ts
+++ b/src/ts/ssh-tcp/services/localPortForwarder.ts
@@ -77,6 +77,7 @@ export class LocalPortForwarder extends SshService {
 		let listenAddress = this.localIPAddress;
 		try {
 			this.tcpListener = await this.pfs.tcpListenerFactory.createTcpListener(
+				this.remotePort,
 				listenAddress,
 				this.port,
 				true,
@@ -97,6 +98,7 @@ export class LocalPortForwarder extends SshService {
 				listenAddress = this.localIPAddress === '0.0.0.0' ? '::' : '::1';
 				try {
 					this.tcpListener2 = await this.pfs.tcpListenerFactory.createTcpListener(
+						this.remotePort,
 						listenAddress,
 						this.port,
 						false,

--- a/src/ts/ssh-tcp/sshServer.ts
+++ b/src/ts/ssh-tcp/sshServer.ts
@@ -81,6 +81,7 @@ export class SshServer implements Disposable {
 
 		try {
 			this.tcpListener = await this.tcpListenerFactory.createTcpListener(
+				undefined, // remotePort
 				localAddress,
 				localPort,
 				false,

--- a/src/ts/ssh-tcp/tcpListenerFactory.ts
+++ b/src/ts/ssh-tcp/tcpListenerFactory.ts
@@ -37,7 +37,7 @@ export interface TcpListenerFactory {
 		remotePort: number | undefined,
 		localIPAddress: string,
 		localPort: number,
-		canChangePort: boolean,
+		canChangeLocalPort: boolean,
 		cancellation?: CancellationToken,
 	): Promise<net.Server>;
 }
@@ -47,7 +47,7 @@ export class DefaultTcpListenerFactory implements TcpListenerFactory {
 		remotePort: number | undefined,
 		localIPAddress: string,
 		localPort: number,
-		canChangePort: boolean,
+		canChangeLocalPort: boolean,
 		cancellation?: CancellationToken,
 	): Promise<net.Server> {
 		if (!localIPAddress) throw new TypeError('Local IP address is required.');

--- a/src/ts/ssh-tcp/tcpListenerFactory.ts
+++ b/src/ts/ssh-tcp/tcpListenerFactory.ts
@@ -10,11 +10,12 @@ export interface TcpListenerFactory {
 	 * Creates and starts a TCP listener for the specified local network address and port
 	 * number.
 	 *
+	 * @param remotePort The remote port that this local port will connect to (if known).
 	 * @param localIPAddress Local IP address to listen on.
 	 * @param localPort Requested local port to listen on, or 0 to use a random
 	 * available port number.
-	 * @param canChangePort True if the factory is allowed to select a different
-	 * port number than the one that was requested; if false then the factory must either
+	 * @param canChangeLocalPort True if the factory is allowed to select a different
+	 * local port number than the one that was requested; if false then the factory must either
 	 * use the requested port or throw an exception.</param>
 	 * @param cancellation">Cancellation token.</param>
 	 * @returns TCP listener object that has started listening.</returns>
@@ -33,6 +34,7 @@ export interface TcpListenerFactory {
 	 * obtain the actual port from the returned listener's `localEndpoint` property.
 	 */
 	createTcpListener(
+		remotePort: number | undefined,
 		localIPAddress: string,
 		localPort: number,
 		canChangePort: boolean,
@@ -42,6 +44,7 @@ export interface TcpListenerFactory {
 
 export class DefaultTcpListenerFactory implements TcpListenerFactory {
 	public async createTcpListener(
+		remotePort: number | undefined,
 		localIPAddress: string,
 		localPort: number,
 		canChangePort: boolean,

--- a/test/cs/Ssh.Test/PortForwardingTests.cs
+++ b/test/cs/Ssh.Test/PortForwardingTests.cs
@@ -162,7 +162,7 @@ public class PortForwardingTests : IDisposable
 			int? remotePort,
 			IPAddress localIPAddress,
 			int localPort,
-			bool canChangePort,
+			bool canChangeLocalPort,
 			TraceSource trace,
 			CancellationToken cancellation)
 		{

--- a/test/cs/Ssh.Test/PortForwardingTests.cs
+++ b/test/cs/Ssh.Test/PortForwardingTests.cs
@@ -159,6 +159,7 @@ public class PortForwardingTests : IDisposable
 		}
 
 		public Task<TcpListener> CreateTcpListenerAsync(
+			int? remotePort,
 			IPAddress localIPAddress,
 			int localPort,
 			bool canChangePort,

--- a/test/ts/ssh-test/portForwardingTests.ts
+++ b/test/ts/ssh-test/portForwardingTests.ts
@@ -53,7 +53,7 @@ class TestTcpListenerFactory implements TcpListenerFactory {
 		remotePort: number | undefined,
 		localIPAddress: string,
 		localPort: number,
-		canChangePort: boolean,
+		canChangeLocalPort: boolean,
 	): Promise<net.Server> {
 		const listener = net.createServer();
 		await new Promise((resolve, reject) => {

--- a/test/ts/ssh-test/portForwardingTests.ts
+++ b/test/ts/ssh-test/portForwardingTests.ts
@@ -50,6 +50,7 @@ class TestTcpListenerFactory implements TcpListenerFactory {
 	public constructor(public readonly localPortOverride: number) { }
 
 	public async createTcpListener(
+		remotePort: number | undefined,
 		localIPAddress: string,
 		localPort: number,
 		canChangePort: boolean,

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-	"version": "3.11",
+	"version": "3.12",
 	"publicReleaseRefSpec": [
 		"^refs/heads/main$",
 		"^refs/heads/releases/.+$"


### PR DESCRIPTION
This addresses a bug in the dev tunnels CLI / SDK: it can print the wrong remote port number for an IPv6 client connection endpoint when the original port number was in use.

    > devtunnel connect neat-field-5zxbcmv       
    Connected to tunnel: neat-field-5zxbcmv
    SSH: Forwarding from 127.0.0.1:9001 to host port 9000.
    SSH: Forwarding from [::1]:9001 to host port 9001.

In the example above, the IPv6 port 9001 is actually forwarding to host port 9000, the same as IPv4. The console output there is wrong. (This only happens if port 9000 was in use before the command was run.)

With the `remotePort` parameter added in this change, the dev tunnels SDK  [RetryTcpListenerFactory](https://github.com/microsoft/dev-tunnels/blob/main/cs/src/Connections/RetryTcpListenerFactory.cs) can be updated to use the `remotePort` instead of `localPort` in the message `"Forwarding from {listener.LocalEndpoint} to host port {localPort}."`.

Additionally, this can allow for a future capability for a tunnel client to map host port numbers to different arbitrary client port numbers.