### PR TITLE
Update to .NET 8 SDK

### DIFF
--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -26,17 +26,21 @@ jobs:
 
     name: Build SSH on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    env:
+      DYLD_FALLBACK_LIBRARY_PATH: $DYLD_FALLBACK_LIBRARY_PATH:/usr/local/lib
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      # On the Mac build machines, libssl 1.1 is installed
-      # but not linked in the path expected by .NET. Fix it now.
+      # On the Mac build machines, openssl v3 is installed but
+      # dylibs are not linked in a path that can be found by .NET.
       - name: Link libssl on Mac OS
         run: |
           sudo mkdir -p /usr/local/lib
-          sudo ln -sn /usr/local/opt/openssl@1.1/lib/libssl.1.1.dylib /usr/local/lib/libssl.1.1.dylib
+          export OPENSSL3_VERSION=$(brew list --versions openssl@3 | head -n 1 | sed "s/.* //")
+          sudo ln -sfn $(brew --prefix)/Cellar/openssl\@3/$OPENSSL3_VERSION/lib/libssl.3.dylib /usr/local/lib/libssl.3.dylib
+          sudo ln -sfn $(brew --prefix)/Cellar/openssl\@3/$OPENSSL3_VERSION/lib/libcrypto.3.dylib /usr/local/lib/libcrypto.3.dylib
         if: matrix.os == 'macOS-latest'
 
       - name: Install dotnet versions

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -31,13 +31,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      # On the Mac build machines, libssl 1.1 is not installed
-      # but is required for some .NET crypto algorithms.
-      - name: Install libssl on Mac OS
+      # On the Mac build machines, libssl 1.1 is installed
+      # but not linked in the path expected by .NET. Fix it now.
+      - name: Link libssl on Mac OS
         run: |
-          brew install openssl@1.1
-          brew info openssl
-          ln -sfn $(brew --prefix)/opt/openssl@1.1/lib/libssl.1.1.dylib /usr/local/lib/libssl.1.1.dylib
+          sudo mkdir -p /usr/local/lib
+          ln -sn /usr/local/opt/openssl@1.1/lib/libssl.1.1.dylib /usr/local/lib/libssl.1.1.dylib
         if: matrix.os == 'macOS-latest'
 
       - name: Install dotnet versions

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -12,6 +12,11 @@ on:
         required: false
         default: false
 
+permissions:
+  contents: read
+  actions: read
+  checks: write # Required by test-reporter
+
 jobs:
   builds:
     strategy:
@@ -26,18 +31,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      # On the Mac build machines, libssl 1.1 is installed
-      # but not linked in the path expected by .NET. Fix it now.
-      - name: Link libssl on Mac OS
-        run: ln -sn /usr/local/opt/openssl@1.1/lib/libssl.1.1.dylib /usr/local/lib/libssl.1.1.dylib
-        if: matrix.os == 'macOS-latest'
-
       - name: Install dotnet versions
         uses: actions/setup-dotnet@v2
         with:
           dotnet-version: |
-            3.1.x
-            6.0.x
+            8.0.x
 
       - name: Use global.json dotnet version
         uses: actions/setup-dotnet@v2
@@ -70,12 +68,8 @@ jobs:
         run: npm run test-ts
         continue-on-error: true
 
-      - name: Test .NET Core 3.1
-        run: npm run test-cs -- --release --serial --framework netcoreapp3.1
-        continue-on-error: true
-
-      - name: Test .NET 6
-        run: npm run test-cs -- --release --serial --framework net6.0
+      - name: Test .NET 8
+        run: npm run test-cs -- --release --serial --framework net8.0
         continue-on-error: true
 
       - name: Test .NET Framework 4.8

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Link libssl on Mac OS
         run: |
           sudo mkdir -p /usr/local/lib
-          ln -sn /usr/local/opt/openssl@1.1/lib/libssl.1.1.dylib /usr/local/lib/libssl.1.1.dylib
+          sudo ln -sn /usr/local/opt/openssl@1.1/lib/libssl.1.1.dylib /usr/local/lib/libssl.1.1.dylib
         if: matrix.os == 'macOS-latest'
 
       - name: Install dotnet versions

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -31,6 +31,15 @@ jobs:
         with:
           fetch-depth: 0
 
+      # On the Mac build machines, libssl 1.1 is not installed
+      # but is required for some .NET crypto algorithms.
+      - name: Install libssl on Mac OS
+        run: |
+          brew install openssl@1.1
+          brew info openssl
+          ln -sfn $(brew --prefix)/opt/openssl@1.1/lib/libssl.1.1.dylib /usr/local/lib/libssl.1.1.dylib
+        if: matrix.os == 'macOS-latest'
+
       - name: Install dotnet versions
         uses: actions/setup-dotnet@v2
         with:

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -27,7 +27,7 @@ jobs:
     name: Build SSH on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -41,17 +41,17 @@ jobs:
         if: matrix.os == 'macOS-latest'
 
       - name: Install dotnet versions
-        uses: actions/setup-dotnet@v2
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
             8.0.x
 
       - name: Use global.json dotnet version
-        uses: actions/setup-dotnet@v2
+        uses: actions/setup-dotnet@v4
         with:
           global-json-file: global.json
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: '20.x'
 

--- a/.pipelines/dev-tunnels-ssh-ci.yaml
+++ b/.pipelines/dev-tunnels-ssh-ci.yaml
@@ -216,15 +216,14 @@ jobs:
         clean: true
         fetchTags: false
 
-      # On the Mac build machines, libssl 1.1 is not installed
-      # but is required for some .NET crypto algorithms.
+      # On the Mac build machines, libssl 1.1 is installed
+      # but not linked in the path expected by .NET. Fix it now.
       - task: CmdLine@2
-        displayName: Install libssl
+        displayName: Link libssl
         inputs:
           script: |
-            brew install openssl@1.1
-            brew info openssl
-            ln -sfn $(brew --prefix)/opt/openssl@1.1/lib/libssl.1.1.dylib /usr/local/lib/libssl.1.1.dylib
+            sudo mkdir -p /usr/local/lib
+            ln -sn /usr/local/opt/openssl@1.1/lib/libssl.1.1.dylib /usr/local/lib/libssl.1.1.dylib
 
       - task: UseDotNet@2
         displayName: Install .NET 8 Runtime

--- a/.pipelines/dev-tunnels-ssh-ci.yaml
+++ b/.pipelines/dev-tunnels-ssh-ci.yaml
@@ -216,6 +216,16 @@ jobs:
         clean: true
         fetchTags: false
 
+      # On the Mac build machines, libssl 1.1 is not installed
+      # but is required for some .NET crypto algorithms.
+      - task: CmdLine@2
+        displayName: Install libssl
+        inputs:
+          script: |
+            brew install openssl@1.1
+            brew info openssl
+            ln -sfn $(brew --prefix)/opt/openssl@1.1/lib/libssl.1.1.dylib /usr/local/lib/libssl.1.1.dylib
+
       - task: UseDotNet@2
         displayName: Install .NET 8 Runtime
         inputs:

--- a/.pipelines/dev-tunnels-ssh-ci.yaml
+++ b/.pipelines/dev-tunnels-ssh-ci.yaml
@@ -210,20 +210,24 @@ jobs:
     variables:
       - name: Codeql.SkipTaskAutoInjection
         value: true
+      - name: DYLD_FALLBACK_LIBRARY_PATH
+        value: $(DYLD_FALLBACK_LIBRARY_PATH):/usr/local/lib
     steps:
       - checkout: self
         fetchDepth: -1
         clean: true
         fetchTags: false
 
-      # On the Mac build machines, libssl 1.1 is installed
-      # but not linked in the path expected by .NET. Fix it now.
+      # On the Mac build machines, openssl v3 is installed but
+      # dylibs are not linked in a path that can be found by .NET.
       - task: CmdLine@2
         displayName: Link libssl
         inputs:
           script: |
             sudo mkdir -p /usr/local/lib
-            sudo ln -sn /usr/local/opt/openssl@1.1/lib/libssl.1.1.dylib /usr/local/lib/libssl.1.1.dylib
+            export OPENSSL3_VERSION=$(brew list --versions openssl@3 | head -n 1 | sed "s/.* //")
+            sudo ln -sfn $(brew --prefix)/Cellar/openssl\@3/$OPENSSL3_VERSION/lib/libssl.3.dylib /usr/local/lib/libssl.3.dylib
+            sudo ln -sfn $(brew --prefix)/Cellar/openssl\@3/$OPENSSL3_VERSION/lib/libcrypto.3.dylib /usr/local/lib/libcrypto.3.dylib
 
       - task: UseDotNet@2
         displayName: Install .NET 8 Runtime

--- a/.pipelines/dev-tunnels-ssh-ci.yaml
+++ b/.pipelines/dev-tunnels-ssh-ci.yaml
@@ -125,18 +125,11 @@ jobs:
           customCommand: run test-ts -- --release --serial --coverage
 
       - task: Npm@1
-        displayName: Test (.NET Core 3.1)
+        displayName: Test (.NET 8)
         inputs:
           command: custom
           verbose: false
-          customCommand: run test-cs -- --release --serial --coverage --framework netcoreapp3.1
-
-      - task: Npm@1
-        displayName: Test (.NET 6)
-        inputs:
-          command: custom
-          verbose: false
-          customCommand: run test-cs -- --release --serial --coverage --framework net6.0
+          customCommand: run test-cs -- --release --serial --coverage --framework net8.0
 
       - task: Npm@1
         displayName: Test (.NET Framework 4.8)
@@ -223,24 +216,11 @@ jobs:
         clean: true
         fetchTags: false
 
-      # On the Mac build machines, libssl 1.1 is installed
-      # but not linked in the path expected by .NET. Fix it now.
-      - task: CmdLine@2
-        displayName: Link libssl
-        inputs:
-          script: ln -sn /usr/local/opt/openssl@1.1/lib/libssl.1.1.dylib /usr/local/lib/libssl.1.1.dylib
-
       - task: UseDotNet@2
-        displayName: Install .NET Core 3.1 Runtime
+        displayName: Install .NET 8 Runtime
         inputs:
           packageType: runtime
-          version: 3.1.x
-
-      - task: UseDotNet@2
-        displayName: Install .NET 6 Runtime
-        inputs:
-          packageType: runtime
-          version: 6.0.x
+          version: 8.0.x
 
       - task: UseDotNet@2
         displayName: Use .NET SDK specified by global.json
@@ -275,16 +255,8 @@ jobs:
           customCommand: run test-ts -- --release --serial
 
       - task: Npm@1
-        displayName: Test (.NET Core 3.1)
-        enabled: False
+        displayName: Test (.NET 8)
         inputs:
           command: custom
           verbose: false
-          customCommand: run test-cs -- --release --serial --framework netcoreapp3.1
-
-      - task: Npm@1
-        displayName: Test (.NET 6)
-        inputs:
-          command: custom
-          verbose: false
-          customCommand: run test-cs -- --release --serial --framework net6.0
+          customCommand: run test-cs -- --release --serial --framework net8.0

--- a/.pipelines/dev-tunnels-ssh-ci.yaml
+++ b/.pipelines/dev-tunnels-ssh-ci.yaml
@@ -223,7 +223,7 @@ jobs:
         inputs:
           script: |
             sudo mkdir -p /usr/local/lib
-            ln -sn /usr/local/opt/openssl@1.1/lib/libssl.1.1.dylib /usr/local/lib/libssl.1.1.dylib
+            sudo ln -sn /usr/local/opt/openssl@1.1/lib/libssl.1.1.dylib /usr/local/lib/libssl.1.1.dylib
 
       - task: UseDotNet@2
         displayName: Install .NET 8 Runtime

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,7 +20,7 @@
 	  "editor.formatOnSave": true
 	},
 	"files.insertFinalNewline": false,
-	"dotnetCoreExplorer.searchpatterns": "out/bin/Debug/*/netcoreapp3.1/*.Test.dll",
+	"dotnetCoreExplorer.searchpatterns": "out/bin/Debug/*/net8.0/*.Test.dll",
 	"typescript.tsdk": "node_modules/typescript/lib",
 	"mochaExplorer.debuggerConfig": "Attach Debugger",
 	"mochaExplorer.env": {

--- a/README-dev.md
+++ b/README-dev.md
@@ -37,7 +37,7 @@ npm run test-cs
 To run/debug an individual test case or subset of test cases matching a
 substring, use a command similar to the following:
 ```
-npm run test-cs --framework netcoreapp3.1 --filter crypto
+npm run test-cs --framework net8.0 --filter crypto
 ```
 Or open `SSH.sln` in Visual Studio 2019 and use the Test Explorer.
 

--- a/bench/cs/Directory.Build.props
+++ b/bench/cs/Directory.Build.props
@@ -3,7 +3,7 @@
 	<Import Project="../../Directory.Build.props" />
 
 	<PropertyGroup>
-		<TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
+		<TargetFrameworks>net8.0</TargetFrameworks>
 		<TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net48;$(TargetFrameworks)</TargetFrameworks>
 
 		<IsPackable>false</IsPackable>

--- a/build.js
+++ b/build.js
@@ -36,7 +36,7 @@ yargs.option('release', {
 });
 yargs.option('framework', {
 	desc: 'Specify .net application framework',
-	choices: ['net48', 'netcoreapp2.1', 'netcoreapp3.1', 'net6.0', 'netstandard2.1'],
+	choices: ['net48', 'net8.0', 'netstandard2.1'],
 	group: buildGroup,
 });
 yargs.option('msbuild', {
@@ -358,9 +358,9 @@ async function linkLib(packageName, dirName) {
 }
 
 function getTargetAppFramework(framework) {
-	if (!framework || framework == 'netstandard2.1' || framework == 'netcoreapp3.1') {
-		return 'netcoreapp3.1';
-	} else if (framework == 'net6.0' || framework == 'net48') {
+	if (!framework || framework == 'netstandard2.1') {
+		return 'net8.0';
+	} else if (framework == 'net8.0' || framework == 'net48') {
 		return framework;
 	} else {
 		throw new Error('Invalid target framework: ' + framework);

--- a/build/config.props
+++ b/build/config.props
@@ -44,23 +44,19 @@
 	</ItemGroup>
 
 	<PropertyGroup>
-		<DotNetStandard20 Condition="'$(TargetFramework)'=='netstandard2.0' OR '$(TargetFramework)'=='netcoreapp2.1'">true</DotNetStandard20>
-		<DotNetStandard21 Condition="'$(TargetFramework)'=='netstandard2.1' OR '$(TargetFramework)'=='netcoreapp3.1'">true</DotNetStandard21>
+		<DotNetStandard21 Condition="'$(TargetFramework)'=='netstandard2.1' OR '$(TargetFramework)'=='net8.0'">true</DotNetStandard21>
 		<DotNet4 Condition="$(TargetFramework.StartsWith('net4'))">true</DotNet4>
-		<DotNet5 Condition="'$(TargetFramework)'=='net5.0'">true</DotNet5>
-		<DotNet6 Condition="'$(TargetFramework)'=='net6.0'">true</DotNet6>
+		<DotNet8 Condition="'$(TargetFramework)'=='net8.0'">true</DotNet8>
 
-		<DefineConstants Condition="'$(DotNetStandard20)'=='true'">$(DefineConstants);NETSTANDARD2_0</DefineConstants>
 		<DefineConstants Condition="'$(DotNetStandard21)'=='true'">$(DefineConstants);NETSTANDARD2_1</DefineConstants>
 		<DefineConstants Condition="'$(DotNet4)'=='true'">$(DefineConstants);NET4</DefineConstants>
-		<DefineConstants Condition="'$(DotNet5)'=='true'">$(DefineConstants);NET5_0</DefineConstants>
-		<DefineConstants Condition="'$(DotNet6)'=='true'">$(DefineConstants);NET6_0</DefineConstants>
+		<DefineConstants Condition="'$(DotNet8)'=='true'">$(DefineConstants);NET8_0</DefineConstants>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(DotNet4)'=='true'">
 		<DefineConstants>$(DefineConstants);SSH_ENABLE_ECDH</DefineConstants>
 		<DefineConstants>$(DefineConstants);SSH_ENABLE_PBKDF2</DefineConstants>
 	</PropertyGroup>
-	<PropertyGroup Condition="'$(DotNetStandard21)'=='true' OR '$(DotNet5)'=='true' OR '$(DotNet6)' == 'true'">
+	<PropertyGroup Condition="'$(DotNetStandard21)'=='true' OR '$(DotNet8)' == 'true'">
 		<DefineConstants>$(DefineConstants);SSH_ENABLE_SPAN</DefineConstants>
 		<DefineConstants>$(DefineConstants);SSH_ENABLE_AESGCM</DefineConstants>
 		<DefineConstants>$(DefineConstants);SSH_ENABLE_PBKDF2</DefineConstants>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
 	"sdk": {
-		"version": "6.0.405",
+		"version": "8.0.400",
 		"rollForward": "latestFeature"
 	}
 }

--- a/src/cs/Directory.Build.props
+++ b/src/cs/Directory.Build.props
@@ -35,7 +35,7 @@
 		<CodeAnalysisRuleSet>$(SshBuildDirectory)CodeAnalysis.ruleset</CodeAnalysisRuleSet>
 	</PropertyGroup>
 
-	<PropertyGroup Condition="'$(TargetFramework)' == 'net6.0'">
+	<PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
 		<IsTrimmable>true</IsTrimmable><!-- Enable trimmability warnings -->
 	</PropertyGroup>
 

--- a/src/cs/Ssh/Algorithms/SshAlgorithm.cs
+++ b/src/cs/Ssh/Algorithms/SshAlgorithm.cs
@@ -84,7 +84,7 @@ public abstract class SshAlgorithm
 	[UnconditionalSuppressMessage(
 		"Trimming",
 		"IL2026:RequiresUnreferencedCode",
-		Justification = "Crypto types will no be trimmed because they're referenced elsewhere.")]
+		Justification = "Crypto types will not be trimmed because they're referenced elsewhere.")]
 #endif
 	private static Assembly? InitializeOpenSslAssembly()
 	{
@@ -100,46 +100,20 @@ public abstract class SshAlgorithm
 			return null;
 		}
 
-		// Try to P/Invoke into libssl 1.1, just to check whether it can be loaded. Otherwise
-		// the .NET OpenSSL initialization may abort the process when it fails to load libssl.
-		try
+		if (!CheckOpensslVersion())
 		{
-			if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-			{
-				// On Mac, .NET prefers v1.1 but also supports v1.0.
-				try
-				{
-					_ = GetOpenSsl11VersionMac();
-				}
-				catch (DllNotFoundException)
-				{
-					try
-					{
-						_ = GetOpenSsl10VersionMac();
-					}
-					catch (EntryPointNotFoundException)
-					{
-						// The version_num entrypoint doesn't exist in older versions.
-						// That's fine -- this at least confirms the library was loaded.
-					}
-				}
-			}
-			else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-			{
-				// On Linux, .NET always prefers v1.1, but supports several other versions
-				// depending on the distro. Ignore other versions here to keep it simple.
-				_ = GetOpenSsl11VersionLinux();
-			}
-		}
-		catch (DllNotFoundException)
-		{
+			// Failed to load libssl. The library might be not installed or not found in the
+			// dynamic-library search path. On Mac OS, it may be necessary to set
+			// DYLD_FALLBACK_LIBRARY_PATH to a directory containing libssl*.dylib.
 			return null;
 		}
 
 		// Ensure the crypto interop is initialized. Unfortunately this relies on an
 		// internal type, but there's no better way to ensure OpenSSL is actually available
-		// before trying to really use it.
-		var interopCryptoType = opensslAssembly.GetType("Interop+Crypto");
+		// before trying to really use it. Depending on the .NET version, the type could be
+		// in either System.Security.Cryptography or System.Security.Cryptography.OpenSsl.
+		var interopCryptoType = typeof(SymmetricAlgorithm).Assembly.GetType("Interop+Crypto") ??
+			opensslAssembly.GetType("Interop+Crypto");
 		if (interopCryptoType == null)
 		{
 			// The internal interop type was not found. Since it's internal, it could get moved
@@ -161,6 +135,85 @@ public abstract class SshAlgorithm
 		return opensslAssembly;
 	}
 
+	/// <summary>
+	/// Try to P/Invoke the libssl version API, just to check whether it can be loaded. Otherwise
+	/// the .NET OpenSSL initialization may abort the process when it fails to load libssl.
+	/// </summary>
+	private static bool CheckOpensslVersion()
+	{
+		if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+		{
+			// On Mac, .NET 8 supports OpenSSL v3, v1.1, and v1.0.
+			// Older .NET versions support v1.1 and v1.0.
+			if (Environment.Version.Major >= 8)
+			{
+				try
+				{
+					_ = GetOpenSsl3VersionMac();
+					return true;
+				}
+				catch (DllNotFoundException)
+				{
+				}
+			}
+
+			try
+			{
+				_ = GetOpenSsl11VersionMac();
+				return true;
+			}
+			catch (DllNotFoundException)
+			{
+			}
+
+			try
+			{
+				_ = GetOpenSsl10VersionMac();
+				return true;
+			}
+			catch (DllNotFoundException)
+			{
+			}
+			catch (EntryPointNotFoundException)
+			{
+				// The version_num entrypoint doesn't exist in v1.0.
+				// That's fine -- this at least confirms the library was loaded.
+				return true;
+			}
+		}
+		else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+		{
+			// On Linux, .NET 8 supports OpenSSL v3 and v1.1.
+			// Older .NET versions support v1.1.
+			if (Environment.Version.Major >= 8)
+			{
+				try
+				{
+					_ = GetOpenSsl3VersionLinux();
+					return true;
+				}
+				catch (DllNotFoundException)
+				{
+				}
+			}
+
+			try
+			{
+				_ = GetOpenSsl11VersionLinux();
+				return true;
+			}
+			catch (DllNotFoundException)
+			{
+			}
+		}
+
+		return false;
+	}
+
+	[DllImport("libssl.3.dylib", EntryPoint = "OpenSSL_version_num")]
+	[DefaultDllImportSearchPaths(DllImportSearchPath.SafeDirectories)]
+	private static extern int GetOpenSsl3VersionMac();
+
 	[DllImport("libssl.1.1.dylib", EntryPoint = "OpenSSL_version_num")]
 	[DefaultDllImportSearchPaths(DllImportSearchPath.SafeDirectories)]
 	private static extern int GetOpenSsl11VersionMac();
@@ -168,6 +221,10 @@ public abstract class SshAlgorithm
 	[DllImport("libssl.1.0.0.dylib", EntryPoint = "OpenSSL_version_num")]
 	[DefaultDllImportSearchPaths(DllImportSearchPath.SafeDirectories)]
 	private static extern int GetOpenSsl10VersionMac();
+
+	[DllImport("libssl.so.3", EntryPoint = "OpenSSL_version_num")]
+	[DefaultDllImportSearchPaths(DllImportSearchPath.SafeDirectories)]
+	private static extern int GetOpenSsl3VersionLinux();
 
 	[DllImport("libssl.so.1.1", EntryPoint = "OpenSSL_version_num")]
 	[DefaultDllImportSearchPaths(DllImportSearchPath.SafeDirectories)]

--- a/test/cs/Directory.Build.props
+++ b/test/cs/Directory.Build.props
@@ -3,7 +3,7 @@
 	<Import Project="../../Directory.Build.props" />
 
 	<PropertyGroup>
-		<TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
+		<TargetFrameworks>net8.0</TargetFrameworks>
 		<TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net48;$(TargetFrameworks)</TargetFrameworks>
 
 		<IsPackable>false</IsPackable>
@@ -25,12 +25,12 @@
 
 	<PropertyGroup>
 		<!-- AltCover properties -->
-		<AltCover Condition=" '$(CodeCoverage)' == 'true' AND '$(TargetFramework)' == 'netcoreapp3.1' ">true</AltCover>
+		<AltCover Condition=" '$(CodeCoverage)' == 'true' AND '$(TargetFramework)' == 'net8.0' ">true</AltCover>
 		<AltCoverXmlReport>$(TestResultsDirectory)/$(MSBuildProjectName)-coverage.xml</AltCoverXmlReport>
 		<AltCoverAssemblyExcludeFilter>Test|xunit|AltCover</AltCoverAssemblyExcludeFilter>
 		<AltCoverTypeFilter>System.Runtime|CodeAnalysis|ThisAssembly</AltCoverTypeFilter>
 
-		<ReportGeneratorTool>$(NuGetPackageRoot)ReportGenerator\4.6.7\tools\netcoreapp3.0\ReportGenerator.exe</ReportGeneratorTool>
+		<ReportGeneratorTool>$(NuGetPackageRoot)ReportGenerator\4.6.7\tools\net8.0\ReportGenerator.exe</ReportGeneratorTool>
 	</PropertyGroup>
 
 </Project>

--- a/test/cs/Ssh.Test/CryptoTests.cs
+++ b/test/cs/Ssh.Test/CryptoTests.cs
@@ -21,7 +21,7 @@ public class CryptoTests
 	{
 		var alg = GetAlgorithmByName<KeyExchangeAlgorithm>(
 			typeof(SshAlgorithms.KeyExchange), kexAlg);
-		Assert.True(alg.IsAvailable);
+		Assert.True(alg.IsAvailable, $"Algorithm not available: {kexAlg}");
 
 		using var kexA = alg.CreateKeyExchange();
 		using var kexB = alg.CreateKeyExchange();
@@ -46,7 +46,7 @@ public class CryptoTests
 	{
 		var alg = GetAlgorithmByName<PublicKeyAlgorithm>(
 			typeof(SshAlgorithms.PublicKey), pkAlg);
-		Assert.True(alg.IsAvailable);
+		Assert.True(alg.IsAvailable, $"Algorithm not available: {pkAlg}");
 
 		var keyPair = alg.GenerateKeyPair(keySize);
 
@@ -71,7 +71,7 @@ public class CryptoTests
 	{
 		var alg = GetAlgorithmByName<EncryptionAlgorithm>(
 			typeof(SshAlgorithms.Encryption), encAlg);
-		Assert.True(alg.IsAvailable);
+		Assert.True(alg.IsAvailable, $"Algorithm not available: {encAlg}");
 
 		var key = new Buffer(alg.KeyLength);
 		var iv = new Buffer(alg.BlockLength);
@@ -116,7 +116,7 @@ public class CryptoTests
 	{
 		var alg = GetAlgorithmByName<HmacAlgorithm>(
 			typeof(SshAlgorithms.Hmac), hmacAlg);
-		Assert.True(alg.IsAvailable);
+		Assert.True(alg.IsAvailable, $"Algorithm not available: {hmacAlg}");
 
 		var key = new Buffer(alg.KeyLength);
 


### PR DESCRIPTION
[.NET 6 end of life is coming up in a couple months](https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core), and .NET 3.1 has been unsupported for years. So we should stop using those .NET versions. Library projects continue to target `netstandard2.1` and `net48`, so this change does not impact applications that consume the libraries.

 - Update from .NET 6 to .NET 8 SDK in `global.json`.
 - Update from .NET Core 3.1 + .NET 6 to .NET 8 for test and benchmark projects.
 - Update code in `SshAlgorithm.cs` for detecting and loading libssl. .NET 8 changed something that affected the detection. And it added support for libssl v3, though we can still fall back to v1.1 or v1.0.
 - Update PR and CI build steps accordingly.
 - Fix the build step to link libssl on Mac OS, as it was failing on the current Mac OS build agents. Update it to v3, and fix `DYLD_FALLBACK_LIBRARY_PATH` environment variable which doesn't seem to be set in the GH action. (It is supposed to include /usr/local/lib by default, so this shouldn't be a problem for users.)
 - Fix GitHub action permissions for the test-reporter.
