### PR TITLE
Use MSI for ESRP code signing

### DIFF
--- a/.pipelines/dev-tunnels-ssh-ci.yaml
+++ b/.pipelines/dev-tunnels-ssh-ci.yaml
@@ -182,21 +182,18 @@ jobs:
           publishFeedCredentials: 'dev-tunnels-nuget'
           publishPackageMetadata: true
   
-      - task: EsrpRelease@7
+      - task: EsrpRelease@9
         condition: and(succeeded(), eq('${{ parameters.PublishNpmPackage }}', 'true'))
         inputs:
           connectedservicename: 'Devtunnels-esrp-ame-msi'
+          usemanagedidentity: true
           keyvaultname: 'tunnels-ppe-esrp-kv'
-          authcertname: 'esrp-cert'
           signcertname: 'esrp-sign'
           clientid: '142047f4-eda8-4853-8776-c2e81803ea13'
-          intent: 'PackageDistribution'
           contenttype: 'npm'
           folderLocation: '$(System.DefaultWorkingDirectory)/out/pkg'
-          waitforreleasecompletion: true
           owners: 'jfullerton@microsoft.com'
           approvers: 'jasongin@microsoft.com, debekoe@microsoft.com, ilbiryuk@microsoft.com'
-          serviceendpointurl: 'https://api.esrp.microsoft.com'
           mainpublisher: 'ESRPRELPACMAN'
           domaintenantid: '33e01921-4d64-4f8c-a055-5bdaffd5e33d'
 

--- a/.pipelines/dev-tunnels-ssh-ci.yaml
+++ b/.pipelines/dev-tunnels-ssh-ci.yaml
@@ -181,11 +181,12 @@ jobs:
           nuGetFeedType: external
           publishFeedCredentials: 'dev-tunnels-nuget'
           publishPackageMetadata: true
+  
       - task: EsrpRelease@7
         condition: and(succeeded(), eq('${{ parameters.PublishNpmPackage }}', 'true'))
         inputs:
-          connectedservicename: 'Devtunnels-esrp-cert-based'
-          keyvaultname: 'tunnels-dev-kv'
+          connectedservicename: 'Devtunnels-esrp-ame-msi'
+          keyvaultname: 'tunnels-ppe-esrp-kv'
           authcertname: 'esrp-cert'
           signcertname: 'esrp-sign'
           clientid: '142047f4-eda8-4853-8776-c2e81803ea13'
@@ -197,7 +198,7 @@ jobs:
           approvers: 'jasongin@microsoft.com, debekoe@microsoft.com, ilbiryuk@microsoft.com'
           serviceendpointurl: 'https://api.esrp.microsoft.com'
           mainpublisher: 'ESRPRELPACMAN'
-          domaintenantid: '72f988bf-86f1-41af-91ab-2d7cd011db47'
+          domaintenantid: '33e01921-4d64-4f8c-a055-5bdaffd5e33d'
 
   - job: mac
     displayName: SSH Mac


### PR DESCRIPTION
Similar to changes for https://dev.azure.com/devdiv/OnlineServices/_git/tunnels/pullrequest/605463

Followed the TSG https://eng.ms/docs/microsoft-security/identity/trust-and-security-services/tss-high-security-environments/tss-esrp-fabric-and-platform-services/esrp-documentation/tsgs/sfi/tsg506-integrating-esrp-release-ado-extension