### PR TITLE
Use DevTunnels1ESHostedPool to see if that fixes ESRPRelease step

### DIFF
--- a/.pipelines/dev-tunnels-ssh-ci.yaml
+++ b/.pipelines/dev-tunnels-ssh-ci.yaml
@@ -32,7 +32,10 @@ jobs:
     displayName: 'SSH Windows'
     timeoutInMinutes: '90'
     pool:
-      name: VSEngSS-MicroBuild2022-1ES
+      type: linux
+      isCustom: true
+      name: DevTunnels1ESHostedPool
+      vmImage: 'tunnels-test-1es-hosted-for-cli-pipeline'
 
     steps:
       - checkout: self

--- a/src/cs/Ssh/SshSession.cs
+++ b/src/cs/Ssh/SshSession.cs
@@ -177,7 +177,7 @@ public class SshSession : IDisposable
 	/// <summary>
 	/// Event is raised when a keep-alive request is sent but no response is received
 	/// </summary>
-	public event EventHandler<SshKeepAliveEventArgs>? KeepAliveRequestFailed;
+	public event EventHandler<SshKeepAliveEventArgs>? KeepAliveFailed;
 
 	/// <summary>
 	/// Gets the set of protocol extensions (and their values) enabled for the current session.
@@ -523,7 +523,7 @@ public class SshSession : IDisposable
 									TraceEventType.Warning,
 									SshTraceEventIds.KeepAliveResponseNotReceived,
 									"Keep alive response not received.");
-								KeepAliveRequestFailed?.Invoke(
+								KeepAliveFailed?.Invoke(
 									this,
 									new SshKeepAliveEventArgs(keepAliveFailureCount));
 							}

--- a/test/cs/Ssh.Test/SessionTests.cs
+++ b/test/cs/Ssh.Test/SessionTests.cs
@@ -778,7 +778,7 @@ public class SessionTests : IDisposable
 		int keepAliveFailedCount = 0;
 
 		var firstRequest = new SessionRequestMessage { RequestType = "first", WantReply = true };
-		sessionPair2.ClientSession.KeepAliveRequestFailed += (sender, e) =>
+		sessionPair2.ClientSession.KeepAliveFailed += (sender, e) =>
 		{
 			keepAliveFailedCount = e.Count;
 		};


### PR DESCRIPTION
Also rename `KeepAliveRequestFailed` to `KeepAliveFailed` as it was suggested in SDK PR