### PR TITLE
Implement keep alive success callback for Codespaces

### DIFF
--- a/src/cs/Ssh/SshSession.cs
+++ b/src/cs/Ssh/SshSession.cs
@@ -181,9 +181,9 @@ public class SshSession : IDisposable
 	public event EventHandler<SshKeepAliveEventArgs>? KeepAliveFailed;
 
 	/// <summary>
-	/// Event is raised when a keep-alive request is sent and a response is received
+	/// Event is raised when a keep-alive response is received
 	/// </summary>
-	public event EventHandler<SshKeepAliveEventArgs>? KeepAliveReceived;
+	public event EventHandler<SshKeepAliveEventArgs>? KeepAliveSucceeded;
 
 	/// <summary>
 	/// Gets the set of protocol extensions (and their values) enabled for the current session.
@@ -538,7 +538,7 @@ public class SshSession : IDisposable
 							{
 								keepAliveFailureCount = 0;
 								keepAliveSuccessCount++;
-								KeepAliveReceived?.Invoke(
+								KeepAliveSucceeded?.Invoke(
 									this,
 									new SshKeepAliveEventArgs(keepAliveSuccessCount));
 							}

--- a/test/cs/Ssh.Test/SessionTests.cs
+++ b/test/cs/Ssh.Test/SessionTests.cs
@@ -719,7 +719,7 @@ public class SessionTests : IDisposable
 			new SshClientCredentials(TestUsername, TestPassword)).WithTimeout(Timeout);
 		Assert.True(authenticated);
 		int keepAliveCount = 0;
-		sessionPair2.ClientSession.KeepAliveReceived += (sender, e) =>
+		sessionPair2.ClientSession.KeepAliveSucceeded += (sender, e) =>
 		{
 			keepAliveCount++;
 		};


### PR DESCRIPTION
We implemented keep alive failure callback and that helped us implement reconnects etc.
This will help in understanding if keep alive messages are being sent. This will help investigate connection issues without downloading the agent logs (These logs are huge and a pain to download)