### PR TITLE
Update ESRP release task to version 11

### DIFF
--- a/.pipelines/dev-tunnels-ssh-ci.yaml
+++ b/.pipelines/dev-tunnels-ssh-ci.yaml
@@ -206,7 +206,7 @@ jobs:
           publishFeedCredentials: 'dev-tunnels-nuget'
           publishPackageMetadata: true
 
-      - task: EsrpRelease@9
+      - task: EsrpRelease@11
         condition: and(succeeded(), eq('${{ parameters.PublishNpmPackage }}', 'true'))
         inputs:
           connectedservicename: 'Devtunnels-esrp-ame-msi'
@@ -214,8 +214,9 @@ jobs:
           keyvaultname: 'tunnels-ppe-esrp-kv'
           signcertname: 'esrp-sign'
           clientid: '142047f4-eda8-4853-8776-c2e81803ea13'
+          intent: 'PackageDistribution'
           contenttype: 'npm'
-          folderLocation: '$(System.DefaultWorkingDirectory)/out/pkg'
+          folderlocation: '$(System.DefaultWorkingDirectory)/out/pkg'
           owners: 'jfullerton@microsoft.com'
           approvers: 'jasongin@microsoft.com, debekoe@microsoft.com, ilbiryuk@microsoft.com'
           mainpublisher: 'ESRPRELPACMAN'


### PR DESCRIPTION
This is just to remove a warning in the build as version 9 is using an unsupported version of nodejs.