### PR TITLE
Fix StreamForwarder crashing host process on unhandled socket errors

### DIFF
--- a/src/ts/ssh-tcp/services/streamForwarder.ts
+++ b/src/ts/ssh-tcp/services/streamForwarder.ts
@@ -19,8 +19,24 @@ export class StreamForwarder implements Disposable {
 		if (!localStream) throw new TypeError('Local stream is required.');
 		if (!remoteStream) throw new TypeError('Remote stream is required.');
 
+		// Without these listeners, errors from either side of the forwarder
+		// propagate up to the Node process as unhandled 'error' events and
+		// crash the host. Node's pipe() does not propagate errors between
+		// streams, so each side must be handled independently.
+		localStream.on('error', (err) => this.onStreamError('local', err));
+		remoteStream.on('error', (err) => this.onStreamError('remote', err));
+
 		localStream.pipe(remoteStream);
 		remoteStream.pipe(localStream);
+	}
+
+	private onStreamError(side: 'local' | 'remote', err: Error): void {
+		this.trace(
+			TraceLevel.Warning,
+			SshTraceEventIds.unknownError,
+			`Stream forwarder ${side} stream error: ${err.message}`,
+		);
+		this.dispose();
 	}
 
 	private close(abort: boolean, errorMessage?: string): void {


### PR DESCRIPTION
## Problem

`StreamForwarder` pipes two Duplex streams together but never attaches
`'error'` listeners on either side. When the underlying transport resets
(SSH channel aborted by remote, TCP reset on the local socket, keepalive
timeout), the stream emits an `'error'` event with zero listeners and Node
crashes the entire host process with:

```
node:events:486
      throw er; // Unhandled 'error' event
      ^

Error: read ECONNRESET
    at TCP.onStreamRead (node:internal/stream_base_commons:216:20)
Emitted 'error' event on Socket instance at:
    at Socket.onerror (node:internal/streams/readable:1031:14)
    at Socket.emit (node:events:508:28)
    at emitErrorNT (node:internal/streams/destroy:170:8)
    at emitErrorCloseNT (node:internal/streams/destroy:129:3)
```

Reproduces with any Node app using `TunnelRelayTunnelClient` with multiple
forwarded ports under bursty load - any channel reset during teardown is
fatal.

## Root cause

`services/streamForwarder.ts` constructor pipes `localStream` <-> `remoteStream`
with no error handlers. Node's `.pipe()` does not propagate errors between
streams, so each side must be handled independently.

## Fix

Attach `'error'` listeners on both streams in the constructor. On error,
trace the event and dispose the forwarder (which already has correct
idempotent teardown logic via `this.disposed`).

## Changes

| File | Change |
| ---- | ------ |
| `src/ts/ssh-tcp/services/streamForwarder.ts` | Attach error listeners in constructor; graceful dispose on error |

## Testing

Verified locally with a Node app forwarding multiple ports through
`TunnelRelayTunnelClient`: before this change, triggering a channel
reset kills the host process within seconds. After, the stream disposes
cleanly with a warning trace and the host process continues running.

Happy to add a unit test if requested - didn't see an existing test
pattern for StreamForwarder error propagation in `test/ts/ssh-tcp/`,
so wanted to sanity-check scope first.

Fixes #137