### PR TITLE
Fix channel-open cancellation deadlock in ConnectionService

### DIFF
--- a/src/cs/Ssh/Services/ConnectionService.cs
+++ b/src/cs/Ssh/Services/ConnectionService.cs
@@ -49,6 +49,14 @@ internal class ConnectionService : SshService
 	private long channelCounter = -1;
 	private Exception? closedException = null;
 
+	/// <summary>
+	/// Test-only hook invoked while holding <see cref="lockObject"/> in the channel-open
+	/// confirmation handler, right before the pending channel's cancellation registration is
+	/// captured. Tests use this to deterministically reproduce the channel-open cancellation
+	/// race. Always null (a no-op) in production.
+	/// </summary>
+	internal Action? TestHook_ChannelOpenResponseLocked { get; set; }
+
 	public ConnectionService(SshSession session) : base(session)
 	{
 		this.channels = new Dictionary<uint, SshChannel>();
@@ -500,6 +508,8 @@ internal class ConnectionService : SshService
 			{
 				openMessage = pendingChannel.OpenMessage;
 				completionSource = pendingChannel.CompletionSource;
+
+				this.TestHook_ChannelOpenResponseLocked?.Invoke();
 
 				// Capture the registration and dispose it AFTER releasing the lock.
 				// Disposing here would deadlock: the callback registered in

--- a/src/cs/Ssh/Services/ConnectionService.cs
+++ b/src/cs/Ssh/Services/ConnectionService.cs
@@ -492,6 +492,7 @@ internal class ConnectionService : SshService
 
 		TaskCompletionSource<SshChannel>? completionSource = null;
 		ChannelOpenMessage openMessage;
+		CancellationTokenRegistration cancellationRegistration = default;
 		lock (this.lockObject)
 		{
 			if (this.pendingChannels.TryGetValue(
@@ -499,7 +500,14 @@ internal class ConnectionService : SshService
 			{
 				openMessage = pendingChannel.OpenMessage;
 				completionSource = pendingChannel.CompletionSource;
-				pendingChannel.CancellationRegistration.Dispose();
+
+				// Capture the registration and dispose it AFTER releasing the lock.
+				// Disposing here would deadlock: the callback registered in
+				// OpenChannelAsync also acquires this.lockObject, and
+				// CancellationTokenRegistration.Dispose() blocks until an in-flight
+				// callback completes. Removing the pending channel under the lock
+				// makes the callback a no-op, so deferring the dispose is safe.
+				cancellationRegistration = pendingChannel.CancellationRegistration;
 				this.pendingChannels.Remove(message.RecipientChannel);
 			}
 			else if (this.channels.ContainsKey(message.RecipientChannel))
@@ -534,6 +542,8 @@ internal class ConnectionService : SshService
 			this.channels.Add(channel.ChannelId, channel);
 		}
 
+		cancellationRegistration.Dispose();
+
 		var args = new SshChannelOpeningEventArgs(openMessage, channel, isRemoteRequest: false);
 		await Session.OnChannelOpeningAsync(args, cancellation).ConfigureAwait(false);
 
@@ -565,16 +575,23 @@ internal class ConnectionService : SshService
 		cancellation.ThrowIfCancellationRequested();
 
 		TaskCompletionSource<SshChannel>? completionSource = null;
+		CancellationTokenRegistration cancellationRegistration = default;
 		lock (this.lockObject)
 		{
 			if (this.pendingChannels.TryGetValue(
 				message.RecipientChannel, out var pendingChannel))
 			{
 				completionSource = pendingChannel.CompletionSource;
-				pendingChannel.CancellationRegistration.Dispose();
+
+				// Capture the registration and dispose it after releasing the lock;
+				// disposing under the lock can deadlock with the cancellation callback
+				// (which also acquires this.lockObject). See HandleMessageAsync above.
+				cancellationRegistration = pendingChannel.CancellationRegistration;
 				this.pendingChannels.Remove(message.RecipientChannel);
 			}
 		}
+
+		cancellationRegistration.Dispose();
 
 		if (completionSource != null)
 		{

--- a/test/cs/Ssh.Test/ChannelTests.cs
+++ b/test/cs/Ssh.Test/ChannelTests.cs
@@ -183,11 +183,11 @@ public class ChannelTests : IDisposable
 	/// reflection (as <see cref="ReconnectTests"/> does for KeyRotationThreshold) so the test
 	/// otherwise uses only the public session API. The hook runs on the receive pump thread
 	/// while it holds the ConnectionService lock during open-confirmation processing: it cancels
-	/// the open (whose callback, registered in OpenChannelAsync, also acquires that lock) from
-	/// another thread and then sleeps so the callback is in-flight and blocked on the lock.
-	/// Before the fix, the pump then disposed the cancellation registration while still holding
-	/// the lock, which blocks on the in-flight callback and deadlocks the session; after the fix
-	/// the registration is disposed after the lock is released.
+	/// the open from another thread, using CancellationToken LIFO callback ordering to
+	/// deterministically confirm the internal callback is contending for the held lock before
+	/// returning. Before the fix, the pump then disposed the cancellation registration while
+	/// still holding the lock, which blocks on the in-flight callback and deadlocks the session;
+	/// after the fix the registration is disposed after the lock is released.
 	/// </summary>
 	private static void InstallOpenCancelRaceHook(
 		SshSession session, CancellationTokenSource cancellationSource)
@@ -210,12 +210,24 @@ public class ChannelTests : IDisposable
 			// Fire only once, on the first (raced) open confirmation.
 			hookProperty.SetValue(connectionService, null);
 
-			// Cancel from another thread; the open's cancellation callback then contends for
-			// the ConnectionService lock, which the pump currently holds here.
+			// We need the cancellation callback to be actively contending for our held lock
+			// before this hook returns. CancellationToken callbacks fire in LIFO order on the
+			// thread that calls Cancel(). The internal callback (registered in OpenChannelAsync)
+			// was registered BEFORE this one, so ours fires FIRST. Once ours completes,
+			// Cancel() immediately invokes the internal callback on the same thread — which
+			// blocks on lockObject that we hold here. So when callbackStarted completes, the
+			// internal callback is guaranteed to be contending for the lock (same-thread
+			// sequential execution within Cancel(), zero scheduling gap).
+			var callbackStarted = new TaskCompletionSource<bool>(
+				TaskCreationOptions.RunContinuationsAsynchronously);
+
+			// Registered AFTER the internal callback → fires FIRST (LIFO).
+			cancellationSource.Token.Register(() => callbackStarted.SetResult(true));
+
 			Task.Run(() => cancellationSource.Cancel());
 
-			// Give the cancellation callback time to reach and block on the lock.
-			Thread.Sleep(500);
+			// When this returns, the internal callback is already blocked on lockObject.
+			callbackStarted.Task.Wait();
 		};
 
 		hookProperty.SetValue(connectionService, hook);

--- a/test/cs/Ssh.Test/ChannelTests.cs
+++ b/test/cs/Ssh.Test/ChannelTests.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -174,6 +175,107 @@ public class ChannelTests : IDisposable
 					SshChannelOpenFailureReason.ConnectFailed,
 				((SshChannelException)ex).Message);
 		}
+	}
+
+	/// <summary>
+	/// Installs a test hook on the client's internal ConnectionService that deterministically
+	/// reproduces the channel-open cancellation race. The internal hook is reached via
+	/// reflection (as <see cref="ReconnectTests"/> does for KeyRotationThreshold) so the test
+	/// otherwise uses only the public session API. The hook runs on the receive pump thread
+	/// while it holds the ConnectionService lock during open-confirmation processing: it cancels
+	/// the open (whose callback, registered in OpenChannelAsync, also acquires that lock) from
+	/// another thread and then sleeps so the callback is in-flight and blocked on the lock.
+	/// Before the fix, the pump then disposed the cancellation registration while still holding
+	/// the lock, which blocks on the in-flight callback and deadlocks the session; after the fix
+	/// the registration is disposed after the lock is released.
+	/// </summary>
+	private static void InstallOpenCancelRaceHook(
+		SshSession session, CancellationTokenSource cancellationSource)
+	{
+		var connectionServiceType = typeof(SshSession).Assembly.GetType(
+			"Microsoft.DevTunnels.Ssh.Services.ConnectionService");
+		var activateMethod = typeof(SshSession).GetMethods()
+			.Single(m => m.Name == nameof(SshSession.ActivateService) &&
+				m.IsGenericMethodDefinition &&
+				m.GetParameters().Length == 0)
+			.MakeGenericMethod(connectionServiceType);
+		var connectionService = activateMethod.Invoke(session, null);
+
+		var hookProperty = connectionServiceType.GetProperty(
+			"TestHook_ChannelOpenResponseLocked",
+			BindingFlags.NonPublic | BindingFlags.Instance);
+
+		Action hook = () =>
+		{
+			// Fire only once, on the first (raced) open confirmation.
+			hookProperty.SetValue(connectionService, null);
+
+			// Cancel from another thread; the open's cancellation callback then contends for
+			// the ConnectionService lock, which the pump currently holds here.
+			Task.Run(() => cancellationSource.Cancel());
+
+			// Give the cancellation callback time to reach and block on the lock.
+			Thread.Sleep(500);
+		};
+
+		hookProperty.SetValue(connectionService, hook);
+	}
+
+	[Fact]
+	public async Task OpenChannelCancelDuringConfirmationDoesNotDeadlock()
+	{
+		await this.sessionPair.ConnectAsync().WithTimeout(Timeout);
+
+		using var cancellationSource = new CancellationTokenSource();
+		InstallOpenCancelRaceHook(this.clientSession, cancellationSource);
+
+		var openTask = this.clientSession.OpenChannelAsync(
+			(string)null, cancellationSource.Token);
+
+		// Before the fix this times out (the pump thread deadlocks); after the fix the open
+		// completes, whether it ends up cancelled or opened.
+		try
+		{
+			await openTask.WithTimeout(Timeout);
+		}
+		catch (OperationCanceledException)
+		{
+		}
+		catch (SshChannelException)
+		{
+		}
+	}
+
+	[Fact]
+	public async Task SessionRemainsUsableAfterOpenCancelRace()
+	{
+		await this.sessionPair.ConnectAsync().WithTimeout(Timeout);
+
+		using var cancellationSource = new CancellationTokenSource();
+		InstallOpenCancelRaceHook(this.clientSession, cancellationSource);
+
+		var racedOpenTask = this.clientSession.OpenChannelAsync(
+			(string)null, cancellationSource.Token);
+
+		try
+		{
+			await racedOpenTask.WithTimeout(Timeout);
+		}
+		catch (OperationCanceledException)
+		{
+		}
+		catch (SshChannelException)
+		{
+		}
+
+		// If the pump thread had deadlocked, the receive loop could no longer process
+		// messages, so this subsequent open would hang instead of completing end-to-end.
+		var serverChannelTask = this.serverSession.AcceptChannelAsync();
+		var clientChannel = await this.clientSession.OpenChannelAsync().WithTimeout(Timeout);
+		var serverChannel = await serverChannelTask.WithTimeout(Timeout);
+
+		Assert.NotNull(clientChannel);
+		Assert.NotNull(serverChannel);
 	}
 
 	[Theory]

--- a/test/cs/Ssh.Test/ChannelTests.cs
+++ b/test/cs/Ssh.Test/ChannelTests.cs
@@ -183,14 +183,24 @@ public class ChannelTests : IDisposable
 	/// reflection (as <see cref="ReconnectTests"/> does for KeyRotationThreshold) so the test
 	/// otherwise uses only the public session API. The hook runs on the receive pump thread
 	/// while it holds the ConnectionService lock during open-confirmation processing: it cancels
-	/// the open from another thread, using CancellationToken LIFO callback ordering to
-	/// deterministically confirm the internal callback is contending for the held lock before
-	/// returning. Before the fix, the pump then disposed the cancellation registration while
-	/// still holding the lock, which blocks on the in-flight callback and deadlocks the session;
+	/// the open from another thread, using a dual-registration handshake to deterministically
+	/// confirm the internal callback is contending for the held lock before returning.
+	/// A monitoring callback is registered both BEFORE and AFTER the internal one (via
+	/// the returned action and inside the hook). CancellationToken callbacks fire in LIFO
+	/// order on .NET Core and FIFO on .NET Framework — so one of the two monitoring
+	/// callbacks always fires before the internal one. Since Cancel() executes callbacks
+	/// sequentially on the calling thread, once the monitoring callback completes, the
+	/// internal callback starts immediately on the same thread and blocks on lockObject.
+	/// Before the fix, the pump then disposed the cancellation registration while still
+	/// holding the lock, which blocks on the in-flight callback and deadlocks the session;
 	/// after the fix the registration is disposed after the lock is released.
 	/// </summary>
-	private static void InstallOpenCancelRaceHook(
-		SshSession session, CancellationTokenSource cancellationSource)
+	/// <returns>An action that must be invoked after the hook is installed but before
+	/// OpenChannelAsync, to register the "early" monitoring callback.</returns>
+	private static Action InstallOpenCancelRaceHook(
+		SshSession session,
+		CancellationTokenSource cancellationSource,
+		TaskCompletionSource<bool> callbackStarted)
 	{
 		var connectionServiceType = typeof(SshSession).Assembly.GetType(
 			"Microsoft.DevTunnels.Ssh.Services.ConnectionService");
@@ -210,27 +220,32 @@ public class ChannelTests : IDisposable
 			// Fire only once, on the first (raced) open confirmation.
 			hookProperty.SetValue(connectionService, null);
 
-			// We need the cancellation callback to be actively contending for our held lock
-			// before this hook returns. CancellationToken callbacks fire in LIFO order on the
-			// thread that calls Cancel(). The internal callback (registered in OpenChannelAsync)
-			// was registered BEFORE this one, so ours fires FIRST. Once ours completes,
-			// Cancel() immediately invokes the internal callback on the same thread — which
-			// blocks on lockObject that we hold here. So when callbackStarted completes, the
-			// internal callback is guaranteed to be contending for the lock (same-thread
-			// sequential execution within Cancel(), zero scheduling gap).
-			var callbackStarted = new TaskCompletionSource<bool>(
-				TaskCreationOptions.RunContinuationsAsynchronously);
+			// Register a "late" monitoring callback — AFTER the internal callback
+			// (which was registered inside OpenChannelAsync). On LIFO runtimes
+			// (.NET Core) this fires first; on FIFO runtimes (.NET Framework) the
+			// "early" callback registered below fires first. Either way, one of them
+			// signals before the internal callback executes.
+			cancellationSource.Token.Register(
+				() => callbackStarted.TrySetResult(true));
 
-			// Registered AFTER the internal callback → fires FIRST (LIFO).
-			cancellationSource.Token.Register(() => callbackStarted.SetResult(true));
-
+			// Cancel on a background thread. Cancel() invokes all registered
+			// callbacks sequentially on its thread before returning.
 			Task.Run(() => cancellationSource.Cancel());
 
-			// When this returns, the internal callback is already blocked on lockObject.
+			// Wait for a monitoring callback to fire. Since Cancel() executes
+			// callbacks sequentially, the internal callback starts immediately
+			// after the monitoring one completes — on the same thread — and blocks
+			// on lockObject (which the caller holds). So when Wait() returns, the
+			// internal callback is guaranteed to be contending for the lock.
 			callbackStarted.Task.Wait();
 		};
 
 		hookProperty.SetValue(connectionService, hook);
+
+		// Return an action the caller must invoke BEFORE OpenChannelAsync to register
+		// the "early" monitoring callback (covers FIFO runtimes like .NET Framework).
+		return () => cancellationSource.Token.Register(
+			() => callbackStarted.TrySetResult(true));
 	}
 
 	[Fact]
@@ -239,7 +254,14 @@ public class ChannelTests : IDisposable
 		await this.sessionPair.ConnectAsync().WithTimeout(Timeout);
 
 		using var cancellationSource = new CancellationTokenSource();
-		InstallOpenCancelRaceHook(this.clientSession, cancellationSource);
+		var callbackStarted = new TaskCompletionSource<bool>(
+			TaskCreationOptions.RunContinuationsAsynchronously);
+		var registerEarlyCallback = InstallOpenCancelRaceHook(
+			this.clientSession, cancellationSource, callbackStarted);
+
+		// Register "early" monitoring callback BEFORE OpenChannelAsync registers
+		// the internal one. On FIFO (.NET Framework) this fires first.
+		registerEarlyCallback();
 
 		var openTask = this.clientSession.OpenChannelAsync(
 			(string)null, cancellationSource.Token);
@@ -264,7 +286,12 @@ public class ChannelTests : IDisposable
 		await this.sessionPair.ConnectAsync().WithTimeout(Timeout);
 
 		using var cancellationSource = new CancellationTokenSource();
-		InstallOpenCancelRaceHook(this.clientSession, cancellationSource);
+		var callbackStarted = new TaskCompletionSource<bool>(
+			TaskCreationOptions.RunContinuationsAsynchronously);
+		var registerEarlyCallback = InstallOpenCancelRaceHook(
+			this.clientSession, cancellationSource, callbackStarted);
+
+		registerEarlyCallback();
 
 		var racedOpenTask = this.clientSession.OpenChannelAsync(
 			(string)null, cancellationSource.Token);


### PR DESCRIPTION
## Problem

`ConnectionService.HandleMessageAsync` disposed a pending channel's `CancellationTokenRegistration`
while holding `lockObject`. The callback registered in `OpenChannelAsync` also takes `lockObject`,
and `Dispose()` blocks until an in-flight callback completes. So an open cancelling exactly as its
confirmation was processed deadlocked the pump thread, hanging every later `OpenChannelAsync`

## Fix

Dispose the registration **after** releasing the lock. Removing the pending channel under the lock
makes the callback a no-op, so deferring the dispose is safe. Applied to the confirmation and
failure handlers.

## Tests

Added `OpenChannelCancelDuringConfirmationDoesNotDeadlock` and `SessionRemainsUsableAfterOpenCancelRace`,
which force the race via a small internal hook reached by reflection (like `ReconnectTests` does for
`KeyRotationThreshold`).