### PR TITLE
Switch ESRP service connection to wif2 for fix ADO npm publish 

### DIFF
--- a/.pipelines/dev-tunnels-ssh-ci.yaml
+++ b/.pipelines/dev-tunnels-ssh-ci.yaml
@@ -213,7 +213,7 @@ jobs:
       - task: EsrpRelease@11
         condition: and(succeeded(), eq('${{ parameters.PublishNpmPackage }}', 'true'))
         inputs:
-          connectedservicename: 'Devtunnels-esrp-ame-msi'
+          connectedservicename: 'Devtunnels-esrp-ame-msi-wif2'
           usemanagedidentity: true
           keyvaultname: 'tunnels-ppe-esrp-kv'
           signcertname: 'esrp-sign'

--- a/test/cs/Ssh.Test/ChannelTests.cs
+++ b/test/cs/Ssh.Test/ChannelTests.cs
@@ -228,9 +228,10 @@ public class ChannelTests : IDisposable
 			cancellationSource.Token.Register(
 				() => callbackStarted.TrySetResult(true));
 
-			// Cancel on a background thread. Cancel() invokes all registered
-			// callbacks sequentially on its thread before returning.
-			Task.Run(() => cancellationSource.Cancel());
+			// Cancel on a dedicated thread (not the thread pool, which can be
+			// starved under CI load). Cancel() invokes all registered callbacks
+			// sequentially on this thread before returning.
+			new Thread(() => cancellationSource.Cancel()) { IsBackground = true }.Start();
 
 			// Wait for a monitoring callback to fire. Since Cancel() executes
 			// callbacks sequentially, the internal callback starts immediately


### PR DESCRIPTION
The ADO agent pool upgraded from v4 to v5, which changed the OIDC token format for workload identity federation. This broke the ESRP npm publish step with `AADSTS700213: No matching federated identity record found`.

The wif2 service connection was already created and the managed identity's federated credential updated to match it — this was done for the CLI release pipeline in https://devdiv.visualstudio.com/OnlineServices/_git/tunnels/pullrequest/755906 but the SSH pipeline was missed.

This updates the SSH CI pipeline to use `Devtunnels-esrp-ame-msi-wif2` as well.